### PR TITLE
Fix handling of self.curframe being None in parseline

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -428,9 +428,10 @@ class Pdb(pdb.Pdb, ConfigurableClass):
                 cmd = 'inspect'
                 return cmd, arg, newline
 
-        if cmd and hasattr(self, 'do_'+cmd) and (cmd in self.curframe.f_globals or
-                                                 cmd in self.curframe.f_locals or
-                                                 arg.startswith('=')):
+        if cmd and hasattr(self, 'do_'+cmd) and (
+                self.curframe and (cmd in self.curframe.f_globals or
+                                   cmd in self.curframe.f_locals) or
+                arg.startswith('=')):
             line = '!' + line
             return pdb.Pdb.parseline(self, line)
         return cmd, arg, newline


### PR DESCRIPTION
Not sure why/how it might become None in the first place, but it
triggers a bunch of exceptions afterwards.

It is likely related to having multiple `import pdb; pdb.set_trace()`
instances?!

Session:

     607         def get_form(self, request, obj=None, **kwargs):
     608             """
     609             Returns a Form class for use in the admin add view. This is used by
     610             add_view and change_view.
     611             """
     612             if 'fields' in kwargs:
     613                 fields = kwargs.pop('fields')
     614             else:
     615  ->             fields = flatten_fieldsets(self.get_fieldsets(request, obj))
     616             excluded = self.get_exclude(request, obj)
     …
     649     ...
    (Pdb++) self.get_fieldsets(request, obj)
    [(None, {'fields': ['foo', 'bar']})]
    (Pdb++) n
    2017-09-19 17:47:28,961:ERROR:django.request Internal Server Error: /admin/app/model/1/change/
    Traceback (most recent call last):
      File "/home/user/Vcs/django/django/core/handlers/exception.py", line 41, in inner
        response = get_response(request)
      …
      File "/home/user/Vcs/django/django/contrib/admin/options.py", line 615, in get_form
        fields = flatten_fieldsets(self.get_fieldsets(request, obj))
      File "…/pyenv/3.6.2/lib/python3.6/bdb.py", line 48, in trace_dispatch
        return self.dispatch_line(frame)
      File "…/pyenv/3.6.2/lib/python3.6/bdb.py", line 66, in dispatch_line
        self.user_line(frame)
      File "…/pyenv/3.6.2/lib/python3.6/pdb.py", line 261, in user_line
        self.interaction(frame, None)
      File "…/project/.venv/lib/python3.6/site-packages/pdb.py", line 261, in interaction
        self.cmdloop()
      File "…/pyenv/3.6.2/lib/python3.6/cmd.py", line 138, in cmdloop
        stop = self.onecmd(line)
      File "…/pyenv/3.6.2/lib/python3.6/pdb.py", line 418, in onecmd
        return cmd.Cmd.onecmd(self, line)
      File "…/pyenv/3.6.2/lib/python3.6/cmd.py", line 202, in onecmd
        cmd, arg, line = self.parseline(line)
      File "…/project/.venv/lib/python3.6/site-packages/pdb.py", line 435, in parseline
        if cmd and hasattr(self, 'do_'+cmd) and (cmd in self.curframe.f_globals or
    AttributeError: 'NoneType' object has no attribute 'f_globals'