### PR TITLE
add tiny display mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -243,7 +243,7 @@ default value:
   Determine whether pdb++ starts in tiny display mode or not.
   It needs to ``sticky_by_default = True``
 
-``divinding_line = -``
+``divinding_line = '-'``
   The divinding line to use with tiny display mode.
 
 

--- a/README.rst
+++ b/README.rst
@@ -239,6 +239,14 @@ default value:
 ``sticky_by_default = False``
   Determine whether pdb++ starts in sticky mode or not.
 
+``enable_tiny_display = False``
+  Determine whether pdb++ starts in tiny display mode or not.
+  It needs to ``sticky_by_default = True``
+
+``divinding_line = -``
+  The divinding line to use with tiny display mode.
+
+
 ``line_number_color = Color.turquoise``
   The color to use for line numbers.
 

--- a/README.rst
+++ b/README.rst
@@ -243,8 +243,8 @@ default value:
   Determine whether pdb++ starts in tiny display mode or not.
   It needs to ``sticky_by_default = True``
 
-``divinding_line = '-'``
-  The divinding line to use with tiny display mode.
+``dividing_line = '-'``
+  The dividing line to use with tiny display mode.
 
 
 ``line_number_color = Color.turquoise``


### PR DESCRIPTION
### Tiny display mode

It is a compact display mode like as [gdb-dashboard](https://github.com/cyrus-and/gdb-dashboard).

like this (^_^)/

![untitled](https://user-images.githubusercontent.com/17691683/36374508-dcd7611e-15ae-11e8-97b6-4d75db3aa344.gif)
