### PR TITLE
add a heuristic for which 'list' is meant

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,12 @@ Note that the "smart" behavior takes place only when there is ambiguity, i.e.
 if there exists a variable with the same name as a command: in all other
 cases, everything works as usual.
 
+Regarding the ``list`` command itself, using ``list(…`` is a special case
+that gets handled as the Python builtin::
+
+    (Pdb++) list([1, 2])
+    [1, 2]
+
 Additional functions in the ``pdb`` module
 ------------------------------------------
 

--- a/pdb.py
+++ b/pdb.py
@@ -397,6 +397,10 @@ class Pdb(pdb.Pdb, ConfigurableClass):
                                                  arg.startswith('=')):
             line = '!' + line
             return pdb.Pdb.parseline(self, line)
+        if cmd == "list" and arg.startswith("("):
+            # heuristic: handle "list(..." as the builtin.
+            line = '!' + line
+            return pdb.Pdb.parseline(self, line)
         return cmd, arg, newline
 
     def do_inspect(self, arg):

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -516,6 +516,27 @@ NUM  \t   5 frames hidden .*
 """.format(line_num=fn.__code__.co_firstlineno))
 
 
+def test_shortlist_heuristic():
+    def fn():
+        a = 1
+        set_trace(Config=ConfigTest)
+        return a
+
+    check(fn, """
+[NUM] > .*fn()
+-> return a
+   5 frames hidden .*
+# list {line_num}, 3
+NUM  \t    def fn():
+NUM  \t        a = 1
+NUM  \t        set_trace(Config=ConfigTest)
+NUM  ->	        return a
+# list(range(4))
+[0, 1, 2, 3]
+# c
+""".format(line_num=fn.__code__.co_firstlineno))
+
+
 def test_longlist():
     def fn():
         a = 1


### PR DESCRIPTION
The heuristic works as follows: ``list(...`` is the builtin, otherwise it's the pdb++ command.

Fixes https://github.com/antocuni/pdb/issues/69.