### PR TITLE
sticky_by_default is annoying after an error message

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -166,6 +166,7 @@ class Pdb(pdb.Pdb, ConfigurableClass):
         self.mycompleter = None
         self.display_list = {} # frame --> (name --> last seen value)
         self.sticky = self.config.sticky_by_default
+        self.first_time_sticky = self.sticky
         self.sticky_ranges = {} # frame --> (start, end)
         self.tb_lineno = {} # frame --> lineno where the exception raised
         self.history = []
@@ -679,7 +680,10 @@ Frames can marked as hidden in the following ways:
 
     def _print_if_sticky(self):
         if self.sticky:
-            self.stdout.write(CLEARSCREEN)
+            if self.first_time_sticky:
+                self.first_time_sticky = False
+            else:
+                self.stdout.write(CLEARSCREEN)
             frame, lineno = self.stack[self.curindex]
             filename = self.canonic(frame.f_code.co_filename)
             s = '> %s(%r)' % (filename, lineno)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -633,12 +633,24 @@ def test_sticky_by_default():
 [NUM] > .*fn()
 -> a = 1
    5 frames hidden .*
-CLEAR>.*
+.*
 
 NUM         def fn():
 NUM             set_trace(Config=MyConfig)
 NUM  ->         a = 1
 NUM             b = 2
+NUM             c = 3
+NUM             return a
+# n
+[NUM] > .*fn()
+-> b = 2
+   5 frames hidden .*
+CLEAR>.*
+
+NUM         def fn():
+NUM             set_trace(Config=MyConfig)
+NUM             a = 1
+NUM  ->         b = 2
 NUM             c = 3
 NUM             return a
 # c


### PR DESCRIPTION
When using ``sticky_by_default = True`` in combination with ``pytest --pdb`` it's always a bit annoying, because it requires scrolling up to see the error message, since ``sticky`` cleared the screen. This pull request will not do the screen cleaning right after the debugger starts, therefore we can see both the error message *and* the code.

This is just a suggestion, I am open to other ideas how to fix this.