### PR TITLE
set_trace: do not delete pdb.curframe

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -979,9 +979,6 @@ def set_trace(frame=None, Pdb=Pdb, **kwds):
         pdb = Pdb(start_lineno=lineno, start_filename=filename, **kwds)
         GLOBAL_PDB = pdb
 
-    if hasattr(pdb, 'curframe'):
-        del pdb.curframe
-
     pdb.set_trace(frame)
 
 def cleanup():


### PR DESCRIPTION
Deleting `curframe` causes an `AttributeError` later, when `set_trace`
gets invoked during debugger interaction.

This can be triggered using completion, where the completer executes
code that contains a `pdb.set_trace()`, or just by calling a function
that contains it (see
https://github.com/antocuni/pdb/pull/70#issuecomment-353057665).

As for the issue with completion:

Initial traceback to `pdb.set_trace()`:

```
set_trace
  …
  File "…/app/apps.py", line 63, in connection_created_handler
    __import__('pdb').set_trace()
  File "…/project/.venv/lib/python3.6/site-packages/pdb.py", line 994, in set_trace
    traceback.print_stack()
--Return--
[14] > …/app/apps.py(63)connection_created_handler()->None
-> __import__('pdb').set_trace()
```

When completing something `complete` is called like this:

```
(Pdb++) connec<TAB>
complete connec 0
state=0 <frame object at 0x7f0303182048>
mydict: len: 22
complete connec 1
…
```

When completing `connection.` there however, the function containing
`pdb.set_trace` gets called, which then deletes `self.curframe` and
causes `self.complete` to fail (silently) later due to an AttributeError
with `self.curframe.f_globals.copy()`.

Traceback to `set_trace` in that case:

```
  …
  File "…/app/apps.py", line 63, in connection_created_handler
    __import__('pdb').set_trace()
  File "/usr/lib/python3.6/bdb.py", line 52, in trace_dispatch
    return self.dispatch_return(frame, arg)
  File "/usr/lib/python3.6/bdb.py", line 93, in dispatch_return
    self.user_return(frame, arg)
  File "/usr/lib/python3.6/pdb.py", line 293, in user_return
    self.interaction(frame, None)
  File "…/project/.venv/lib/python3.6/site-packages/pdb.py", line 217, in interaction
    self.cmdloop()
  File "/usr/lib/python3.6/cmd.py", line 126, in cmdloop
    line = input(self.prompt)
  File "…/project/.venv/lib/python3.6/site-packages/pdb.py", line 315, in complete
    return self.mycompleter.complete(text, state)
  File "…/project/.venv/lib/python3.6/site-packages/fancycompleter.py", line 244, in complete
    return rlcompleter.Completer.complete(self,text,state)
  File "/usr/lib/python3.6/rlcompleter.py", line 89, in complete
    self.matches = self.attr_matches(text)
  File "…/project/.venv/lib/python3.6/site-packages/fancycompleter.py", line 287, in attr_matches
    value = getattr(object, word)
  File "…/project/.venv/lib/python3.6/site-packages/django/db/backends/postgresql/base.py", line 251, in _nodb_connection
    nodb_connection.ensure_connection()
  File "…/project/.venv/lib/python3.6/site-packages/django/db/backends/base/base.py", line 216, in ensure_connection
    self.connect()
  File "…/project/.venv/lib/python3.6/site-packages/django/db/backends/base/base.py", line 197, in connect
    connection_created.send(sender=self.__class__, connection=self)
  File "…/project/.venv/lib/python3.6/site-packages/django/dispatch/dispatcher.py", line 178, in send
    for receiver in self._live_receivers(sender)
  File "…/project/.venv/lib/python3.6/site-packages/django/dispatch/dispatcher.py", line 178, in <listcomp>
    for receiver in self._live_receivers(sender)
  File "…/app/apps.py", line 63, in connection_created_handler
    __import__('pdb').set_trace()
  File "…/project/.venv/lib/python3.6/site-packages/pdb.py", line 994, in set_trace
    traceback.print_stack()
```

The `del` comes from fb93036, which is rather huge and the `del` does not seem
to be necessary to achieve the described feature (remembering state across
breakpoints).

Therefore it seems like removing the code is a good fix.