### PR TITLE
Handle set_trace being invoked during completion

### DIFF
--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1700,3 +1700,41 @@ def test_python_m_pdb():
     stdout, stderr = p.communicate()
     assert b"usage: pdb.py" in stdout
     assert stderr == b""
+
+
+def test_set_trace_in_completion():
+    def fn():
+        class CompleteMe(object):
+            attr_called = 0
+
+            @property
+            def set_trace_in_attrib(self):
+                self.attr_called += 1
+                set_trace(cleanup=False)
+                print("inner_set_trace_was_ignored")
+
+        obj = CompleteMe()
+
+        set_trace()
+
+        comps = []
+        while True:
+            val = pdb.GLOBAL_PDB.complete("obj.", len(comps))
+            if val is None:
+                break
+            comps += [val]
+        assert obj.attr_called == 1, "attr was called"
+
+        # Colorization only works with pyrepl, via pyrepl.readline._setup?
+        if pdb.GLOBAL_PDB.mycompleter.config.use_colors:
+            assert any("set_trace_in_attrib" in comp for comp in comps)
+        else:
+            assert "set_trace_in_attrib" in comps
+
+    check(fn, """
+[NUM] > .*fn()
+.*
+   5 frames hidden .*
+# c
+inner_set_trace_was_ignored
+""")


### PR DESCRIPTION
This might happen with fancycompleter's `attr_matches`, which might
trigger dynamic properties, like Django's `_nodb_connection` [1].

    File "…/project/.venv/lib/python3.6/site-packages/pdb.py", line 315, in complete
      return self.mycompleter.complete(text, state)
    File "…/project/.venv/lib/python3.6/site-packages/fancycompleter.py", line 244, in complete
      return rlcompleter.Completer.complete(self,text,state)
    File "/usr/lib/python3.6/rlcompleter.py", line 89, in complete
      self.matches = self.attr_matches(text)
    File "…/project/.venv/lib/python3.6/site-packages/fancycompleter.py", line 287, in attr_matches
      value = getattr(object, word)
    File "…/project/.venv/lib/python3.6/site-packages/django/db/backends/postgresql/base.py", line 251, in _nodb_connection
      nodb_connection.ensure_connection()
    File "…/project/.venv/lib/python3.6/site-packages/django/db/backends/base/base.py", line 216, in ensure_connection
      self.connect()
    File "…/project/.venv/lib/python3.6/site-packages/django/db/backends/base/base.py", line 197, in connect
      connection_created.send(sender=self.__class__, connection=self)
    File "…/project/.venv/lib/python3.6/site-packages/django/dispatch/dispatcher.py", line 178, in send
      for receiver in self._live_receivers(sender)
    File "…/project/.venv/lib/python3.6/site-packages/django/dispatch/dispatcher.py", line 178, in <listcomp>
      for receiver in self._live_receivers(sender)
    File "…/app/apps.py", line 63, in connection_created_handler
      __import__('pdb').set_trace()

1: https://github.com/django/django/blob/f185a1fca0223b460c6e1e960f5203616bf8d069/django/db/backends/postgresql/base.py#L248

Includes #88.