### PR TITLE
forget: unset GLOBAL_PDB

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -284,6 +284,8 @@ class Pdb(pdb.Pdb, ConfigurableClass):
             self.print_current_stack_entry()
 
     def forget(self):
+        global GLOBAL_PDB
+        GLOBAL_PDB = None
         pdb.Pdb.forget(self)
         self.raise_lineno = {}
 


### PR DESCRIPTION
This is required with recursive `__import__('pdb').set_trace()` to
create a new instance in `default()`.

Test file:

    def test1():
        __import__('pdb').set_trace()
        test2()

    def test2():
        print(1)

    test1()

Running it and then calling `test1()` twice raises an error without this
patch:

    % python t/t-f_flobals-None.py
    [1] > …/t-f_flobals-None.py(3)test1()
    -> test2()
    (Pdb++) test1()
    (Pdb++) test1()
    Traceback (most recent call last):
      File "/usr/lib/python3.6/cmd.py", line 214, in onecmd
        func = getattr(self, 'do_' + cmd)
    AttributeError: 'Pdb' object has no attribute 'do_test1'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "t-f_flobals-None.py", line 10, in <module>
        test1()
      File "t-f_flobals-None.py", line 3, in test1
        test2()
      File "t-f_flobals-None.py", line 3, in test1
        test2()
      File "/usr/lib/python3.6/bdb.py", line 51, in trace_dispatch
        return self.dispatch_line(frame)
      File "/usr/lib/python3.6/bdb.py", line 69, in dispatch_line
        self.user_line(frame)
      File "/usr/lib/python3.6/pdb.py", line 261, in user_line
        self.interaction(frame, None)
      File "…/Vcs/pdbpp/pdb.py", line 210, in interaction
        self.cmdloop()
      File "/usr/lib/python3.6/cmd.py", line 138, in cmdloop
        stop = self.onecmd(line)
      File "/usr/lib/python3.6/pdb.py", line 418, in onecmd
        return cmd.Cmd.onecmd(self, line)
      File "/usr/lib/python3.6/cmd.py", line 216, in onecmd
        return self.default(line)
      File "…/Vcs/pdbpp/pdb.py", line 438, in default
        return pdb.Pdb.default(self, line)
      File "/usr/lib/python3.6/pdb.py", line 366, in default
        globals = self.curframe.f_globals
AttributeError: 'NoneType' object has no attribute 'f_globals'