### PR TITLE
Revert "Fix handling of self.curframe being None in parseline"

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -384,10 +384,9 @@ class Pdb(pdb.Pdb, ConfigurableClass):
                 cmd = 'inspect'
                 return cmd, arg, newline
 
-        if cmd and hasattr(self, 'do_'+cmd) and (
-                self.curframe and (cmd in self.curframe.f_globals or
-                                   cmd in self.curframe.f_locals) or
-                arg.startswith('=')):
+        if cmd and hasattr(self, 'do_'+cmd) and (cmd in self.curframe.f_globals or
+                                                 cmd in self.curframe.f_locals or
+                                                 arg.startswith('=')):
             line = '!' + line
             return pdb.Pdb.parseline(self, line)
         return cmd, arg, newline


### PR DESCRIPTION
This reverts commit 61d0313e3e37e22b3bd520ae5e2db9c4be214a9f.

The real fix for this is 56aa462 / 74fcde6.

This was done in https://github.com/antocuni/pdb/pull/70 without a test,, #103 fixed it properly.