### PR TITLE
interaction: use _cmdloop if available

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -208,7 +208,8 @@ class Pdb(pdb.Pdb, ConfigurableClass):
         old_completer = completer.config.readline.get_completer()
         completer.config.readline.set_completer(self.complete)
         self.config.before_interaction_hook(self)
-        self.cmdloop()
+        # Use _cmdloop on py3 which catches KeyboardInterrupt.
+        getattr(self, '_cmdloop', self.cmdloop)()
         completer.config.readline.set_completer(old_completer)
         self.forget()
 


### PR DESCRIPTION
This is used with newer Python versions to wrap/catch KeyboardInterrupt.

Makes it consistent with pdb itself (via https://github.com/pytest-dev/pytest/pull/4280#issuecomment-435480443).