### PR TITLE
Fix "python -m pdb"

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -1068,5 +1068,4 @@ def break_on_setattr(attrname, condition=always, set_trace=set_trace):
     return decorator
 
 if __name__=='__main__':
-    import pdb
     pdb.main()

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1574,3 +1574,15 @@ def test_pdbrc_continue(tmpdir):
 'from_pdbrc'
 after_set_trace
 """)
+
+
+def test_python_m_pdb():
+    import subprocess
+
+    p = subprocess.Popen(
+        [sys.executable, "-m", "pdb"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    stdout, stderr = p.communicate()
+    assert b"usage: pdb.py" in stdout
+    assert stderr == b""


### PR DESCRIPTION
Without this patch it fails like this:

    % python -m pdb
    Traceback (most recent call last):
      File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
        "__main__", mod_spec)
      File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "/home/user/Vcs/pdbpp/pdb.py", line 1064, in <module>
        pdb.main()
      File "/usr/lib/python3.7/pdb.py", line 1661, in main
        print(_usage)
    NameError: name '_usage' is not defined