### PR TITLE
config: allow to force use_terminal256formatter

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -89,7 +89,7 @@ class DefaultConfig:
     bg = 'dark'
     use_pygments = True
     colorscheme = None
-    use_terminal256formatter = False
+    use_terminal256formatter = None  # Defaults to `"256color" in $TERM`.
     editor = '${EDITOR:-vi}' # use $EDITOR if set, else default to vi
     stdin_paste = None       # for emacs, you can use my bin/epaste script
     truncate_long_lines = True
@@ -320,10 +320,12 @@ class Pdb(pdb.Pdb, ConfigurableClass):
         if hasattr(self.config, 'formatter'):
             self._fmt = self.config.formatter
         else:
-            Formatter = (Terminal256Formatter
-                         if self.config.use_terminal256formatter
-                            and '256color' in os.environ.get('TERM', '')
-                         else TerminalFormatter)
+            if (self.config.use_terminal256formatter
+                    or (self.config.use_terminal256formatter is None
+                        and "256color" in os.environ.get("TERM", ""))):
+                Formatter = Terminal256Formatter
+            else:
+                Formatter = TerminalFormatter
             self._fmt = Formatter(bg=self.config.bg,
                                   colorscheme=self.config.colorscheme)
         self._lexer = PythonLexer()

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -193,6 +193,31 @@ def check(func, expected):
     assert all_ok
 
 
+def test_config_terminalformatter(monkeypatch):
+    from pdb import DefaultConfig, Pdb
+    import pygments.formatters
+
+    assert DefaultConfig.use_terminal256formatter is None
+
+    monkeypatch.setenv("TERM", "")
+
+    p = Pdb(Config=DefaultConfig)
+    assert p._init_pygments() is True
+    assert isinstance(p._fmt, pygments.formatters.TerminalFormatter)
+
+    p = Pdb(Config=DefaultConfig)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    assert p._init_pygments() is True
+    assert isinstance(p._fmt, pygments.formatters.Terminal256Formatter)
+
+    class Config(DefaultConfig):
+        use_terminal256formatter = False
+
+    p = Pdb(Config=Config)
+    assert p._init_pygments() is True
+    assert isinstance(p._fmt, pygments.formatters.TerminalFormatter)
+
+
 def test_runpdb():
     def fn():
         set_trace()


### PR DESCRIPTION
The default was changed to ``None``, which then uses the previous
``"256color" in $TERM``, but allows to force it to ``True`` now.