### PR TITLE
tests: PdbTest: use nosigint=True

### DIFF
--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -49,11 +49,14 @@ class PdbTest(pdb.Pdb):
 
     def __init__(self, *args, **kwds):
         readrc = kwds.pop("readrc", False)
+        nosigint = kwds.pop("nosigint", True)
         kwds.setdefault('Config', ConfigTest)
         try:
             pdb.Pdb.__init__(self, *args, readrc=readrc, **kwds)
         except TypeError:
             pdb.Pdb.__init__(self, *args, **kwds)
+        # Do not install sigint_handler in do_continue by default.
+        self.nosigint = nosigint
 
     def _open_editor(self, editor, lineno, filename):
         print("RUN %s +%d '%s'" % (editor, lineno, filename))


### PR DESCRIPTION
Without this, "continue" in a test will install `sigint_handler`, which
then might lead to a RuntimeError when readline is trying to be invoked
again (via pytest's `--pdb` and using Ctrl-C then on the outer test).