### PR TITLE
Skip/step over `pdb.set_trace()`

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -1054,6 +1054,12 @@ def set_trace(frame=None, header=None, Pdb=Pdb, **kwds):
 
     if GLOBAL_PDB:
         pdb = GLOBAL_PDB
+        # Unset tracing (gets set py pdb.set_trace below again).
+        # This is required for nested set_trace not stopping in
+        # Bdb._set_stopinfo after deleting stopframe).
+        # There might be a better method (i.e. some flag/property), but this
+        # does it for now.
+        sys.settrace(None)
     else:
         filename = frame.f_code.co_filename
         lineno = frame.f_lineno

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1768,6 +1768,32 @@ def test_recursive_set_trace():
 """)
 
 
+def test_steps_over_set_trace():
+    def fn():
+        set_trace()
+        print(1)
+
+        set_trace(cleanup=False)
+        print(2)
+
+    check(fn, """
+[NUM] > .*fn()
+-> print(1)
+   5 frames hidden .*
+# n
+1
+[NUM] > .*fn()
+-> set_trace(cleanup=False)
+   5 frames hidden .*
+# n
+[NUM] > .*fn()
+-> print(2)
+   5 frames hidden .*
+# c
+2
+""")
+
+
 def test_pdbrc_continue(tmpdir):
     """Test that interaction is skipped with continue in pdbrc."""
     if "readrc" not in inspect.getargs(pdb.pdb.Pdb.__init__.__code__).args:


### PR DESCRIPTION
Without having continued, any `pdb.set_trace()` should be skipped over
with `n`.

Before this patch it would stop in `Bdb._set_stopinfo` after this
deleted/cleared `stopframe`:

    [36] > …/Vcs/pdbpp/testing/test_pdb.py(1774)fn()
    -> print(1)
       5 frames hidden (try 'help hidden_frames')
    # n
    1
    [36] > …/Vcs/pdbpp/testing/test_pdb.py(1776)fn()
    -> set_trace(cleanup=False)
       5 frames hidden (try 'help hidden_frames')
    # n
    [1] > …/pyenv/3.6.7/lib/python3.6/bdb.py(201)_set_stopinfo()
    -> self.returnframe = returnframe
    # c
    [36] > …/Vcs/pdbpp/testing/test_pdb.py(1777)fn()
    -> print(2)
       5 frames hidden (try 'help hidden_frames')
    #

For reference, this was already a problem in 0.8.2 and 0.9.2.