### PR TITLE
Handle _previous_sigint_handler with Python 3.5.3+

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -18,6 +18,7 @@ import traceback
 import subprocess
 import pprint
 import re
+import signal
 from collections import OrderedDict
 from fancycompleter import Completer, ConfigurableClass, Color
 import fancycompleter
@@ -209,6 +210,10 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             pass
 
     def interaction(self, frame, traceback):
+        # Restore the previous signal handler at the Pdb prompt.
+        if getattr(pdb.Pdb, '_previous_sigint_handler', None):
+            signal.signal(signal.SIGINT, pdb.Pdb._previous_sigint_handler)
+            pdb.Pdb._previous_sigint_handler = None
         ret = self.setup(frame, traceback)
         if ret:
             # no interaction desired at this time (happens if .pdbrc contains

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1741,6 +1741,32 @@ ENTERING RECURSIVE DEBUGGER
 """)
 
 
+@pytest.mark.skipif(not hasattr(pdb.pdb.Pdb, "_previous_sigint_handler"),
+                    reason="_previous_sigint_handler is not available")
+def test_interaction_restores_previous_sigint_handler():
+    """Test is based on cpython's test_pdb_issue_20766."""
+    def fn():
+        i = 1
+        while i <= 2:
+            sess = PdbTest(nosigint=False)
+            sess.set_trace(sys._getframe())
+            print('pdb %d: %s' % (i, sess._previous_sigint_handler))
+            i += 1
+
+    check(fn, """
+[NUM] > .*fn()
+-> print('pdb %d: %s' % (i, sess._previous_sigint_handler))
+   5 frames hidden .*
+# c
+pdb 1: <built-in function default_int_handler>
+[NUM] > .*fn()
+-> sess.set_trace(sys._getframe())
+   5 frames hidden .*
+# c
+pdb 2: <built-in function default_int_handler>
+""")
+
+
 def test_recursive_set_trace():
     def fn():
         global inner

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1760,7 +1760,7 @@ def test_interaction_restores_previous_sigint_handler():
 # c
 pdb 1: <built-in function default_int_handler>
 [NUM] > .*fn()
--> sess.set_trace(sys._getframe())
+-> .*
    5 frames hidden .*
 # c
 pdb 2: <built-in function default_int_handler>


### PR DESCRIPTION
Fixes https://github.com/antocuni/pdb/issues/87.