### PR TITLE
Travis: run tests for py32/py33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ python:
 
 jobs:
   include:
+    - stage: test
+      python: '3.2'
+      dist: trusty
+    - python: '3.3'
+      dist: trusty
+
     - stage: release
       script: skip
       install: skip

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Still in setup.py's classifiers, good to know if tests work there.