### PR TITLE
parseline: handle f-strings with py36

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -432,6 +432,11 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
                 cmd = 'inspect'
                 return cmd, arg, newline
 
+        # f-strings.
+        if (cmd == 'f' and len(newline) > 1
+                and (newline[1] == "'" or newline[1] == '"')):
+            return pdb.Pdb.parseline(self, '!' + line)
+
         if cmd and hasattr(self, 'do_'+cmd) and (cmd in self.curframe.f_globals or
                                                  cmd in self.curframe.f_locals or
                                                  arg.startswith('=')):

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -378,6 +378,23 @@ def test_frame():
 """.format(frame_num_a=count_frames() + 2 - 5))
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6),
+                    reason="only with f-strings")
+def test_fstrings():
+    def f():
+        set_trace()
+
+    check(f, """
+--Return--
+[NUM] > .*
+-> set_trace()
+   5 frames hidden .*
+# f"fstring"
+'fstring'
+# c
+""".format(frame_num_a=count_frames() + 2 - 5))
+
+
 def test_up_down_arg():
     def a():
         b()


### PR DESCRIPTION
`f` is used as cmd alias for `frame`, but should not be used with
f-strings.

Related / reminded via: https://github.com/python/cpython/pull/10799