### PR TITLE
do_debug: handle SyntaxError

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -678,7 +678,6 @@ Frames can marked as hidden in the following ways:
             do_debug_func = pdb.Pdb.do_debug
 
         orig_do_debug = rebind_globals(do_debug_func, newglobals)
-
         return orig_do_debug(self, cmd)
     do_debug.__doc__ = pdb.Pdb.do_debug.__doc__
 

--- a/pdb.py
+++ b/pdb.py
@@ -672,7 +672,12 @@ Frames can marked as hidden in the following ways:
             except SyntaxError:
                 import traceback
                 exc_info = sys.exc_info()[:2]
-                self.error(traceback.format_exception_only(*exc_info)[-1].strip())
+                msg = traceback.format_exception_only(*exc_info)[-1].strip()
+                if hasattr(self, 'error'):
+                    self.error(msg)
+                else:
+                    # For pypy2.7-6.0.
+                    print('***', msg, file=self.stdout)
                 return
 
         return orig_do_debug(self, cmd)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1519,6 +1519,23 @@ LEAVING RECURSIVE DEBUGGER
 """)
 
 
+def test_syntaxerror_in_command():
+    def f():
+        set_trace()
+
+    check(f, """
+--Return--
+[NUM] > .*f()
+-> set_trace
+   5 frames hidden .*
+# print(
+\\*\\*\\* SyntaxError: .*
+# debug print(
+\\*\\*\\* SyntaxError: .*
+# c
+""")
+
+
 def test_debug_with_overridden_continue():
     class CustomPdb(PdbTest, object):
         """CustomPdb that overrides do_continue like with pytest's wrapper."""


### PR DESCRIPTION
NOTE: will be fixed in Python 3.7.3 itself
(https://github.com/python/cpython/pull/11782).