### PR TITLE
tests: fix test_signal_in_nonmain_thread_with_interaction

### DIFF
--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2058,13 +2058,13 @@ def test_signal_in_nonmain_thread_with_interaction():
         t = threading.Thread(target=start_thread)
         t.start()
         set_trace(nosigint=False)
+        evt.set()
         t.join()
 
     check(fn, """
 [NUM] > .*fn()
--> t.join()
+-> evt.set()
    5 frames hidden .*
-# evt.set()
 # c
 --Return--
 [NUM] > .*start_thread()->None


### PR DESCRIPTION
Appears to be flaky.

pypy3.5-6.0 failure: https://travis-ci.org/antocuni/pdb/jobs/504075231