### PR TITLE
Make wrapper compatible with python2's sys.stdout

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -177,7 +177,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         if (not hasattr(f, 'stream')
                 and getattr(f, 'encoding', False)
                 and f.encoding.lower() != 'utf-8'):
-            f = codecs.getwriter('utf-8')(f.buffer)
+            f = codecs.getwriter('utf-8')(getattr(f, 'buffer', f) )
 
         return f
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2044,6 +2044,23 @@ def test_ensure_file_can_write_unicode():
     out.seek(0)
     assert out.read().decode("utf-8") == u"test äöüß"
 
+@pytest.mark.skipif(sys.version_info >= (3, 0),
+                    reason="test is python2 specific")
+def test_py2_ensure_file_can_write_unicode():
+    import StringIO
+    from pdb import DefaultConfig, Pdb
+
+    stdout = StringIO.StringIO()
+    stdout.encoding = 'ascii'
+
+    p = Pdb(Config=DefaultConfig, stdout=stdout)
+
+    assert p.stdout.stream is stdout
+
+    p.stdout.write(u"test äöüß")
+    stdout.seek(0)
+    assert stdout.read().decode('utf-8') == u"test äöüß"
+
 
 def test_signal_in_nonmain_thread_with_interaction():
     def fn():


### PR DESCRIPTION
Python2 sys.stdout is not io.TextIOWrapper() so it does not have a buffer attribute.
This reverts returns the prior behavior for python2.7.

Fixes #154