### PR TITLE
DefaultConfig: make it a new-style class

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -70,7 +70,7 @@ def rebind_globals(func, newglobals):
     return newfunc
 
 
-class DefaultConfig:
+class DefaultConfig(object):
     prompt = '(Pdb++) '
     highlight = True
     sticky_by_default = False


### PR DESCRIPTION
This allows to use `super()` in derived classes properly.