### PR TITLE
tests: restore sys.gettrace after test

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,0 +1,28 @@
+import sys
+
+import pytest
+
+_orig_trace = None
+
+
+def pytest_configure():
+    global _orig_trace
+    _orig_trace = sys.gettrace()
+
+
+# if _orig_trace and not hasattr(sys, "pypy_version_info"):
+# Fails with PyPy2 (https://travis-ci.org/antocuni/pdb/jobs/509624590)?!
+@pytest.fixture(autouse=True)
+def restore_settrace():
+    """(Re)store sys.gettrace after test run.
+
+    This is required to re-enable coverage tracking.
+    """
+    assert sys.gettrace() is _orig_trace
+
+    yield
+
+    newtrace = sys.gettrace()
+    if newtrace is not _orig_trace:
+        assert newtrace is None
+        sys.settrace(_orig_trace)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -18,26 +18,6 @@ sys.modules.pop('pdb', None)
 import pdb  # noqa: E402
 
 
-_orig_trace = sys.gettrace()
-
-
-if _orig_trace:
-    @pytest.fixture(autouse=True)
-    def restore_settrace():
-        """(Re)store sys.gettrace after test run.
-
-        This is required to re-enable coverage tracking.
-        """
-        assert sys.gettrace() is _orig_trace
-
-        yield
-
-        newtrace = sys.gettrace()
-        if newtrace is not _orig_trace:
-            assert newtrace is None
-            sys.settrace(_orig_trace)
-
-
 class FakeStdin:
     def __init__(self, lines):
         self.lines = iter(lines)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1863,6 +1863,11 @@ ENTERING RECURSIVE DEBUGGER
 (#) c
 """)
 
+    # Reset pdb, which did not clean up correctly.
+    # Needed for PyPy (Python 2.7.13[pypy-7.1.0-final]) with coverage and
+    # restoring trace function.
+    pdb.GLOBAL_PDB.reset()
+
 
 def test_debug_rebind_globals(monkeypatch):
     class PdbWithCustomDebug(pdb.pdb.Pdb):

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -18,15 +18,22 @@ sys.modules.pop('pdb', None)
 import pdb  # noqa: E402
 
 
+_orig_trace = sys.gettrace()
+
+
 @pytest.fixture(autouse=True)
 def restore_settrace():
     """(Re)store sys.gettrace after test run.
 
     This is required to re-enable coverage tracking.
     """
-    oldtrace = sys.gettrace()
-    yield
-    sys.settrace(oldtrace)
+    if sys.gettrace() is _orig_trace:
+        yield
+        newtrace = sys.gettrace()
+        if newtrace and newtrace is not _orig_trace:
+            sys.settrace(_orig_trace)
+    else:
+        yield
 
 
 class FakeStdin:

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -18,6 +18,14 @@ sys.modules.pop('pdb', None)
 import pdb  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def restore_settrace():
+    "(Re)store sys.gettrace after test run."
+    oldtrace = sys.gettrace()
+    yield
+    sys.settrace(oldtrace)
+
+
 class FakeStdin:
     def __init__(self, lines):
         self.lines = iter(lines)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -20,7 +20,10 @@ import pdb  # noqa: E402
 
 @pytest.fixture(autouse=True)
 def restore_settrace():
-    "(Re)store sys.gettrace after test run."
+    """(Re)store sys.gettrace after test run.
+
+    This is required to re-enable coverage tracking.
+    """
     oldtrace = sys.gettrace()
     yield
     sys.settrace(oldtrace)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -21,20 +21,21 @@ import pdb  # noqa: E402
 _orig_trace = sys.gettrace()
 
 
-@pytest.fixture(autouse=True)
-def restore_settrace():
-    """(Re)store sys.gettrace after test run.
+if _orig_trace:
+    @pytest.fixture(autouse=True)
+    def restore_settrace():
+        """(Re)store sys.gettrace after test run.
 
-    This is required to re-enable coverage tracking.
-    """
-    if sys.gettrace() is _orig_trace:
+        This is required to re-enable coverage tracking.
+        """
+        assert sys.gettrace() is _orig_trace
+
         yield
+
         newtrace = sys.gettrace()
         if newtrace is not _orig_trace:
             assert newtrace is None
             sys.settrace(_orig_trace)
-    else:
-        yield
 
 
 class FakeStdin:

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -30,7 +30,8 @@ def restore_settrace():
     if sys.gettrace() is _orig_trace:
         yield
         newtrace = sys.gettrace()
-        if newtrace and newtrace is not _orig_trace:
+        if newtrace is not _orig_trace:
+            assert newtrace is None
             sys.settrace(_orig_trace)
     else:
         yield


### PR DESCRIPTION
This re-enables coverage tracking after any `pdb.set_trace`.