### PR TITLE
default_pdb_kwargs: remove skip for now

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -93,7 +93,6 @@ class DefaultConfig(object):
 
     # Default keyword arguments passed to ``Pdb`` constructor.
     default_pdb_kwargs = {
-        "skip": ["importlib._bootstrap"],
     }
 
     def setup(self, pdb):


### PR DESCRIPTION
Should include "importlib._bootstrap_external" also/only, but might be
interesting to see/know anyway (without code being displayed).