### PR TITLE
Fix using the debug command multiple times

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -681,9 +681,9 @@ except for when using the function decorator.
         Config = self.ConfigFactory
 
         class PdbppWithConfig(self.__class__):
-            def __init__(self_withcfg, *args):
-                kwds = dict(Config=Config)
-                super(PdbppWithConfig, self_withcfg).__init__(*args, **kwds)
+            def __init__(self_withcfg, *args, **kwargs):
+                kwargs.setdefault("Config", Config)
+                super(PdbppWithConfig, self_withcfg).__init__(*args, **kwargs)
 
                 # Backport of fix for bpo-31078 (not yet merged).
                 self_withcfg.use_rawinput = self.use_rawinput

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -133,7 +133,7 @@ def remove_comment(line):
 
 def extract_commands(lines):
     cmds = []
-    prompts = ('# ', '(#) ')
+    prompts = {'# ', '(#) ', '((#)) ', '(((#))) '}
     for line in lines:
         line = remove_comment(line)
         for prompt in prompts:
@@ -1618,6 +1618,36 @@ LEAVING RECURSIVE DEBUGGER
 """)
 
 
+def test_debug_thrice():
+    def fn():
+        set_trace()
+
+    check(fn, """
+--Return--
+[NUM] > .*fn()
+-> set_trace()
+   5 frames hidden .*
+# debug 1
+ENTERING RECURSIVE DEBUGGER
+[NUM] > .*
+(#) debug 2
+ENTERING RECURSIVE DEBUGGER
+[NUM] > .*
+((#)) debug 34
+ENTERING RECURSIVE DEBUGGER
+[NUM] > .*
+(((#))) p 42
+42
+(((#))) c
+LEAVING RECURSIVE DEBUGGER
+((#)) c
+LEAVING RECURSIVE DEBUGGER
+(#) c
+LEAVING RECURSIVE DEBUGGER
+# c
+""")
+
+
 def test_syntaxerror_in_command():
     expected_debug_err = "ENTERING RECURSIVE DEBUGGER\n\\*\\*\\* SyntaxError: .*"
 
@@ -1678,7 +1708,7 @@ def test_debug_with_overridden_continue():
 # c
 do_continue_1
 [NUM] > .*fn()
--> assert count_continue == 3
+-> return 1
    5 frames hidden .*
 # debug g()
 ENTERING RECURSIVE DEBUGGER

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1708,7 +1708,7 @@ def test_debug_with_overridden_continue():
 # c
 do_continue_1
 [NUM] > .*fn()
--> return 1
+-> assert count_continue == 3
    5 frames hidden .*
 # debug g()
 ENTERING RECURSIVE DEBUGGER


### PR DESCRIPTION
This was broken in 0.9.8 (e24dac1a).