### PR TITLE
Fix completion after debug command

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -220,7 +220,6 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         self.print_stack_entry(self.stack[self.curindex])
         self.print_hidden_frames_count()
         completer = fancycompleter.setup()
-        old_completer = completer.config.readline.get_completer()
         completer.config.readline.set_completer(self.complete)
         self.config.before_interaction_hook(self)
         # Use _cmdloop on py3 which catches KeyboardInterrupt.
@@ -228,7 +227,6 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             self._cmdloop()
         else:
             self.cmdloop()
-        completer.config.readline.set_completer(old_completer)
         self.forget()
 
     def print_hidden_frames_count(self):

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2167,6 +2167,31 @@ Breakpoint NUM at .*
 """ % lineno)
 
 
+def test_completer_after_debug():
+    """Test that pdb's original completion is used."""
+    def fn():
+        myvar = 1  # noqa: F841
+
+        set_trace()
+
+        print("ok_end")
+    check(fn, """
+[NUM] > .*fn()
+.*
+   5 frames hidden .*
+# debug 1
+ENTERING RECURSIVE DEBUGGER
+[1] > <string>(1)<module>()
+(#) c
+LEAVING RECURSIVE DEBUGGER
+# import pdb, readline
+# completer = readline.get_completer()
+# assert isinstance(completer.__self__, pdb.Pdb), completer
+# c
+ok_end
+""")
+
+
 def test_ensure_file_can_write_unicode():
     import io
     from pdb import DefaultConfig, Pdb


### PR DESCRIPTION
This does not restore the old completer anymore, which does not work
with nested calls to `interaction`, since the inner one (via `do_debug`)
would set the completer to `fancycompleter.Completer` again.

An alternative might be to check if it is `Pdb.complete` already (not
easy, since `fancycompleter.setup()` needs to be called and sets this
already), or use some private attribute with the new `Pdb` instance.
But I think it is good to just leave it as-is, given that it get
overwritten/set by fancycompleter anyway already.