### PR TITLE
config: disable current_line_color by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,7 +267,7 @@ default value:
 ``filename_color = Color.yellow``
   The color to use for file names when printing the stack entries.
 
-``current_line_color = 44``
+``current_line_color = False``
   The background color to use to highlight the current line; the background
   color is set by using the ANSI escape sequence ``^[Xm`` where ``^`` is the
   ESC character and ``X`` is the background color. 44 corresponds to "blue".

--- a/README.rst
+++ b/README.rst
@@ -267,10 +267,15 @@ default value:
 ``filename_color = Color.yellow``
   The color to use for file names when printing the stack entries.
 
-``current_line_color = False``
-  The background color to use to highlight the current line; the background
-  color is set by using the ANSI escape sequence ``^[Xm`` where ``^`` is the
-  ESC character and ``X`` is the background color. 44 corresponds to "blue".
+``current_line_color = "39;49;7"``
+  The SGR parameters for the ANSI escape sequence to highlight the current
+  line.
+  This is set inside the SGR escape sequence ``\e[%sm`` where ``\e`` is the
+  ESC character and ``%s`` the given value.  See `SGR parameters`_.
+  The following means "reset all colors" (``0``), set foreground color to 18
+  (``48;5;18``), and background to ``21``.
+  The default uses the default foreground (``39``) and background (``49``)
+  colors, inversed (``7``).
 
 ``use_pygments = True``
   If pygments_ is installed and ``highlight == True``, apply syntax highlight
@@ -327,6 +332,7 @@ default value:
 
 .. _wmctrl: http://bitbucket.org/antocuni/wmctrl
 .. _`pytest`: https://pytest.org/
+.. _SGR parameters: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
 
 
 Coding guidelines

--- a/pdb.py
+++ b/pdb.py
@@ -89,7 +89,7 @@ class DefaultConfig(object):
 
     line_number_color = Color.turquoise
     filename_color = Color.yellow
-    current_line_color = False
+    current_line_color = "39;49;7"  # default fg, bg, inversed
 
     show_traceback_on_error = True
     show_traceback_on_error_limit = None
@@ -109,8 +109,8 @@ def setbgcolor(line, color):
     # hack hack hack
     # add a bgcolor attribute to all escape sequences found
     import re
-    setbg = '\x1b[%dm' % color
-    regexbg = '\\1;%dm' % color
+    setbg = '\x1b[%sm' % color
+    regexbg = '\\1;%sm' % color
     result = setbg + re.sub('(\x1b\\[.*?)m', regexbg, line) + '\x1b[00m'
     if os.environ.get('TERM') == 'eterm-color':
         # it seems that emacs' terminal has problems with some ANSI escape

--- a/pdb.py
+++ b/pdb.py
@@ -89,7 +89,7 @@ class DefaultConfig(object):
 
     line_number_color = Color.turquoise
     filename_color = Color.yellow
-    current_line_color = 44  # blue
+    current_line_color = False
 
     show_traceback_on_error = True
     show_traceback_on_error_limit = None
@@ -426,7 +426,8 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             lineno = Color.set(self.config.line_number_color, lineno)
         line = '%s  %2s %s' % (lineno, marker, line)
         if self.config.highlight and marker == '->':
-            line = setbgcolor(line, self.config.current_line_color)
+            if self.config.current_line_color:
+                line = setbgcolor(line, self.config.current_line_color)
         return line
 
     def parseline(self, line):

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -920,12 +920,14 @@ InnerTestException:
 
 def test_sticky_dunder_exception_with_highlight():
     """Test __exception__ being displayed in sticky mode."""
+    class ConfigWithCurrentLineColor(ConfigWithHighlight):
+        current_line_color = 44
 
     def fn():
         def raises():
             raise InnerTestException()
 
-        set_trace(Config=ConfigWithHighlight)
+        set_trace(Config=ConfigWithCurrentLineColor)
         raises()
 
     check(fn, """
@@ -1035,6 +1037,7 @@ NUM  ->             return 40 \\+ 2
 def test_sticky_dunder_return_with_highlight():
     class ConfigWithPygments(ConfigWithHighlight):
         use_pygments = True
+        current_line_color = 44
 
     def fn():
         def returns():


### PR DESCRIPTION
It might often end up being not readable very well, and there is a
marker already ("->").