### PR TITLE
Fix get_stack for non-last index

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -284,13 +284,15 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
     def get_stack(self, f, t):
         # show all the frames, except the ones that explicitly ask to be hidden
-        fullstack, _ = super(Pdb, self).get_stack(f, t)
+        fullstack, idx = super(Pdb, self).get_stack(f, t)
         self.fullstack = fullstack
-        return self.compute_stack(fullstack)
+        return self.compute_stack(fullstack, idx)
 
-    def compute_stack(self, fullstack):
+    def compute_stack(self, fullstack, idx=None):
+        if idx is None:
+            idx = len(fullstack) - 1
         if self.show_hidden_frames:
-            return fullstack, len(fullstack) - 1
+            return fullstack, idx
 
         self.hidden_frames = []
         newstack = []
@@ -299,9 +301,8 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
                 self.hidden_frames.append((frame, lineno))
             else:
                 newstack.append((frame, lineno))
-        stack = newstack
-        i = max(0, len(stack) - 1)
-        return stack, i
+        newidx = idx - len(self.hidden_frames)
+        return newstack, newidx
 
     def refresh_stack(self):
         """

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -895,16 +895,10 @@ def test_sticky_dunder_exception():
    5 frames hidden (try 'help hidden_frames')
 # n
 .*InnerTestException.*  ### via pdb.Pdb.user_exception (differs on py3/py27)
-[NUM] > .*raises()
--> raise InnerTestException()
+[NUM] > .*fn()
+-> raises()
    5 frames hidden .*
 # sticky
-<CLEARSCREEN>
->.*
-
-NUM             def raises():
-NUM  ->             raise InnerTestException()
-# u
 <CLEARSCREEN>
 > .*test_pdb.py(NUM)
 
@@ -937,16 +931,10 @@ def test_sticky_dunder_exception_with_highlight():
    5 frames hidden (try 'help hidden_frames')
 # n
 .*InnerTestException.*  ### via pdb.Pdb.user_exception (differs on py3/py27)
-[NUM] > .*raises()
--> raise InnerTestException()
+[NUM] > .*fn()
+-> raises()
    5 frames hidden .*
 # sticky
-<CLEARSCREEN>
->.*
-
-<COLORNUM>             def raises():
-<COLORCURLINE>  ->             raise InnerTestException()
-# u
 <CLEARSCREEN>
 > .*test_pdb.py(NUM)
 
@@ -2691,4 +2679,42 @@ Traceback (most recent call last):
   File .*, in f
     f(i)
 # c
+""")
+
+
+def test_next_with_exception_in_call():
+    """Ensure that "next" works correctly with exception (in try/except).
+
+    Previously it would display the frame where the exception occurred, and
+    then "next" would continue, instead of stopping at the next statement.
+    """
+    def fn():
+        def keyerror():
+            raise KeyError
+
+        set_trace()
+        try:
+            keyerror()
+        except KeyError:
+            print("got_keyerror")
+
+    check(fn, """
+[NUM] > .*fn()
+-> try:
+   5 frames hidden .*
+# n
+[NUM] > .*fn()
+-> keyerror()
+   5 frames hidden .*
+# n
+KeyError
+[NUM] > .*fn()
+-> keyerror()
+   5 frames hidden .*
+# n
+[NUM] > .*fn()
+-> except KeyError:
+   5 frames hidden .*
+# c
+got_keyerror
 """)


### PR DESCRIPTION
`Pdb.get_stack` might return an index that is not the last one.  This
patch fixes handling this in `get_stack`/`compute_stack` when hidden
frames are used.