### PR TITLE
complete: display members prefixed with "__"/"_" later

### DIFF
--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2372,7 +2372,13 @@ def test_completes_from_pdb(monkeypatch):
             monkeypatch.setattr("readline.get_begidx", lambda: 2)
             monkeypatch.setattr("readline.get_endidx", lambda: 2)
             comps = get_completions("")
+            assert "where" in comps
+
+            # Dunder members get completed only on second invocation.
+            assert "__name__" not in comps
+            comps = get_completions("")
             assert "__name__" in comps
+            assert 0
 
         # Patch readline to return expected results for "help ".
         monkeypatch.setattr("readline.get_line_buffer", lambda: "help ")

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2378,7 +2378,6 @@ def test_completes_from_pdb(monkeypatch):
             assert "__name__" not in comps
             comps = get_completions("")
             assert "__name__" in comps
-            assert 0
 
         # Patch readline to return expected results for "help ".
         monkeypatch.setattr("readline.get_line_buffer", lambda: "help ")


### PR DESCRIPTION
This makes it much more usable: by default only "non-private" entries
are completed.
There are over ~30 entries prefixed with `__`, but typically they are
not of primary interest.  The same applies to `_`.

Before:
```
__class__          __doc__            __getattribute__   __init_subclass__  __ne__             __repr__           __subclasshook__   token
__delattr__        __eq__             __gt__             __le__             __new__            __setattr__        __weakref__
__dict__           __format__         __hash__           __lt__             __reduce__         __sizeof__         args_check
__dir__            __ge__             __init__           __module__         __reduce_ex__      __str__            resolve
(Pdb++) self.<TAB>
```

After:
```
args_check  resolve     token
(Pdb++) self.<TAB>
```

An additional tab then also displays the others.