### PR TITLE
Skip refreshing sticky display with user_exception

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -981,8 +981,16 @@ except for when using the function decorator.
         else:
             self.print_stack_entry(self.stack[self.curindex])
 
+    def user_exception(self, frame, exc_info):
+        self._skip_sticky = True
+        return super(Pdb, self).user_exception(frame, exc_info)
+
     def preloop(self):
-        self._print_if_sticky()
+        if getattr(self, "_skip_sticky", False):
+            del self._skip_sticky
+        else:
+            self._print_if_sticky()
+
         display_list = self._get_display_list()
         for expr, oldvalue in display_list.items():
             newvalue = self._getval_or_undefined(expr)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1168,6 +1168,47 @@ NUM  ->             return 40 \\+ 2
 """)
 
 
+def test_sticky_with_user_exception_does_not_clear_screen():
+    def fn():
+        def throws():
+            raise InnerTestException()
+
+        set_trace()
+        throws()
+
+    check(fn, """
+[NUM] > .*fn()
+-> throws()
+   5 frames hidden (try 'help hidden_frames')
+# s
+--Call--
+[NUM] > .*throws()
+-> def throws():
+   5 frames hidden .*
+# sticky
+<CLEARSCREEN>
+>.*
+
+NUM  ->         def throws():
+NUM                 raise InnerTestException()
+# n
+[NUM] > .*throws()
+-> raise InnerTestException()
+   5 frames hidden .*
+<CLEARSCREEN>
+>.*
+
+NUM             def throws():
+NUM  ->             raise InnerTestException()
+# n
+testing.test_pdb.InnerTestException
+[NUM] > .*throws()
+-> raise InnerTestException()
+   5 frames hidden .*
+# c
+""")
+
+
 def test_sticky_dunder_return_with_highlight():
     class ConfigWithPygments(ConfigWithHighlight):
         use_pygments = True

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1201,7 +1201,7 @@ NUM                 raise InnerTestException()
 NUM             def throws():
 NUM  ->             raise InnerTestException()
 # n
-testing.test_pdb.InnerTestException
+.*InnerTestException
 [NUM] > .*throws()
 -> raise InnerTestException()
    5 frames hidden .*


### PR DESCRIPTION
The display is not meant to change, and it would clear any extra
information then.