### PR TITLE
Use global Pdb instance via __new__

### DIFF
--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2395,6 +2395,7 @@ Deleted breakpoint NUM
 """ % (line_z, line_z))
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), "header kwarg only with 3.7+")
 def test_set_trace_header():
     """Handler header kwarg added with Python 3.7 in pdb.set_trace."""
     def fn():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2395,7 +2395,7 @@ Deleted breakpoint NUM
 """ % (line_z, line_z))
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), "header kwarg only with 3.7+")
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="header kwarg is 3.7+")
 def test_set_trace_header():
     """Handler header kwarg added with Python 3.7 in pdb.set_trace."""
     def fn():


### PR DESCRIPTION
This is important with pytest using `Pdb().set_trace`, and not
`pdb.set_trace()` - where settings like sticky mode would be not
remembered with the new instance.