### PR TITLE
WIP: Use relative paths by default

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -126,6 +126,8 @@ class DefaultConfig(object):
     default_pdb_kwargs = {
     }
 
+    use_relative_paths = True
+
     def setup(self, pdb):
         pass
 
@@ -573,6 +575,13 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             if _:
                 entry = loc + _ + self.format_source(source).rstrip()
         return entry
+
+    def canonic(self, filename):
+        if self.config.use_relative_paths:
+            relpath = os.path.relpath(filename)
+            if relpath[:2] != "..":
+                return relpath
+        return filename
 
     def try_to_decode(self, s):
         for encoding in self.config.encodings:


### PR DESCRIPTION
Maybe not a good idea since cwd might change during execution etc - but it clearly helps for `bt` to see the source/app itself.