### PR TITLE
Fix (unreleased) regression with missing start attributes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         "fancycompleter>=0.8",
         "wmctrl",
         "pygments",
+        "six",
     ],
     extras_require={
         'funcsigs': ["funcsigs"],

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -3595,3 +3595,27 @@ def test_set_trace_with_incomplete_pdb():
    5 frames hidden .*
 # c
 """)
+
+
+def test_config_gets_start_filename():
+    def fn():
+        setup_lineno = set_trace.__code__.co_firstlineno + 8
+        set_trace_lineno = sys._getframe().f_lineno + 8
+
+        class MyConfig(ConfigTest):
+            def setup(self, pdb):
+                print("config_setup")
+                assert pdb.start_filename == __file__
+                assert pdb.start_lineno == setup_lineno
+
+        set_trace(Config=MyConfig)
+
+        assert pdb.local.GLOBAL_PDB.start_lineno == set_trace_lineno
+
+    check(fn, r"""
+config_setup
+[NUM] > .*fn()
+-> assert pdb.local.GLOBAL_PDB.start_lineno == set_trace_lineno
+   5 frames hidden .*
+# c
+""")

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -66,9 +66,9 @@ class PdbTest(pdb.Pdb):
         readrc = kwds.pop("readrc", False)
         nosigint = kwds.pop("nosigint", True)
         kwds.setdefault('Config', ConfigTest)
-        try:
+        if sys.version_info >= (3, 6):
             super(PdbTest, self).__init__(*args, readrc=readrc, **kwds)
-        except TypeError:
+        else:
             super(PdbTest, self).__init__(*args, **kwds)
         # Do not install sigint_handler in do_continue by default.
         self.nosigint = nosigint


### PR DESCRIPTION
This is not exactly the same as before (which was only done via the
module's `set_trace`), and therefore still gets updated in
`Pdb.set_trace()`.