### PR TITLE
tests: autouse tmphome fixture with Python < 3.6

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -40,7 +40,7 @@ def restore_settrace():
         assert newtrace is None
 
 
-@pytest.fixture
+@pytest.fixture(autouse=sys.version_info < (3, 6))
 def tmphome(tmpdir, monkeypatch):
     """Set up HOME in a temporary directory.
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2818,7 +2818,7 @@ def test_steps_over_set_trace():
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3,), "no support for exit from interaction with pdbrc"
+    sys.version_info < (3,), reason="no support for exit from interaction with pdbrc"
 )
 def test_pdbrc_continue(tmpdir):
     """Test that interaction is skipped with continue in pdbrc."""

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2817,6 +2817,9 @@ def test_steps_over_set_trace():
 """)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3,), "no support for exit from interaction with pdbrc"
+)
 def test_pdbrc_continue(tmpdir):
     """Test that interaction is skipped with continue in pdbrc."""
     with tmpdir.as_cwd():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2819,9 +2819,6 @@ def test_steps_over_set_trace():
 
 def test_pdbrc_continue(tmpdir):
     """Test that interaction is skipped with continue in pdbrc."""
-    if "readrc" not in inspect.getargs(pdb.pdb.Pdb.__init__.__code__).args:
-        pytest.skip("Only with readrc support with pdb.Pdb")
-
     with tmpdir.as_cwd():
         with open(".pdbrc", "w") as f:
             f.writelines([


### PR DESCRIPTION
This is done to simulate readrc=False.