### PR TITLE
parseline: handle `next()` as builtin also

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -705,7 +705,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
                 ) or arg.startswith("="):
                     cmd, arg, newline = None, None, line
                 elif arg.startswith("(") and cmd in ("list", "next"):
-                    # heuristic: handle "list(...", "next(…" etc as builtin.
+                    # heuristic: handle "list(...", "next(..." etc as builtin.
                     cmd, arg, newline = None, None, line
 
         # Fix cmd to not be None when used in completions.

--- a/pdb.py
+++ b/pdb.py
@@ -704,8 +704,8 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
                     and (cmd in self.curframe.f_globals or cmd in self.curframe_locals)
                 ) or arg.startswith("="):
                     cmd, arg, newline = None, None, line
-                elif cmd == "list" and arg.startswith("("):
-                    # heuristic: handle "list(..." as the builtin.
+                elif arg.startswith("(") and cmd in ("list", "next"):
+                    # heuristic: handle "list(...", "next(…" etc as builtin.
                     cmd, arg, newline = None, None, line
 
         # Fix cmd to not be None when used in completions.

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1071,6 +1071,8 @@ def test_parseline_with_existing_command():
 (None, None, 'a = ')
 # print(pdb.local.GLOBAL_PDB.parseline("list()"))
 (None, None, 'list()')
+# print(pdb.local.GLOBAL_PDB.parseline("next(my_iter)"))
+(None, None, 'next(my_iter)')
 # c
 42
 # cont


### PR DESCRIPTION
Without this `next(foo)` would call the `do_next` command.