### PR TITLE
completion: keep only attributes with pdb completions

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -515,6 +515,15 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
             self._filter_completions(text)
 
+            # Remove space used by fancycompleter to not complete common
+            # (color) prefix, if there are completions from pdb.
+            # print(self._completions)
+            if (" " in self._completions
+                    and any(not x.startswith("\x1b")
+                            for x in self._completions
+                            if x != " ")):
+                self._completions.remove(" ")
+
             local._pdbpp_completing = False
 
         try:

--- a/pdb.py
+++ b/pdb.py
@@ -468,6 +468,18 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         finally:
             sys.modules["readline"] = orig_readline
 
+    def _complete_expression(self, text, line, begidx, endidx):
+        """Remove prefixes added with pdb's _complete_expression."""
+        comps = super(Pdb, self)._complete_expression(text, line, begidx, endidx)
+        if '.' not in text:
+            return comps
+
+        dotted = text.split('.')
+        prefix = '.'.join(dotted[:-1]) + '.'
+        prefix_len = len(prefix)
+        return [x[prefix_len:] if x.startswith(prefix) else x
+                for x in comps]
+
     def complete(self, text, state):
         """Handle completions from fancycompleter and original pdb."""
         if state == 0:
@@ -1635,6 +1647,12 @@ for name in 'run runeval runctx runcall pm main set_trace'.split():
     func = getattr(pdb, name)
     globals()[name] = rebind_globals(func, globals())
 del name, func
+
+# Patch completion attributes to use our method.
+for k in pdb.Pdb.__dict__:
+    if (k.startswith("complete_")
+            and getattr(pdb.Pdb, k) == pdb.Pdb._complete_expression):
+        setattr(Pdb, k, Pdb._complete_expression)
 
 
 def post_mortem(t=None, Pdb=Pdb):

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -3382,6 +3382,45 @@ True
 """)
 
 
+def test_complete_uses_attributes_only_from_orig_pdb(
+    monkeypatch_readline, readline_param
+):
+    def fn():
+        def check_completions():
+            # Patch readline to return expected results for "p sys.version".
+            monkeypatch_readline("p sys.version", 2, 13)
+
+            if readline_param == "pyrepl":
+                assert pdb.local.GLOBAL_PDB.fancycompleter.config.use_colors is True
+                assert get_completions("sys.version") == [
+                    "\x1b[000;00m\x1b[32;01mversion\x1b[00m",
+                    "\x1b[001;00m\x1b[00mversion_info\x1b[00m",
+                    " ",
+                ]
+            else:
+                assert pdb.local.GLOBAL_PDB.fancycompleter.config.use_colors is False
+                assert get_completions("sys.version") == [
+                    "version",
+                    "version_info",
+                ]
+            return True
+
+        set_trace()
+
+    _, lineno = inspect.getsourcelines(fn)
+
+    check(fn, """
+--Return--
+[NUM] > .*fn()->None
+.*
+   5 frames hidden .*
+# import sys
+# check_completions()
+True
+# c
+""")
+
+
 @pytest.mark.skipif(sys.version_info < (3, ), reason="py2: no completion for break")
 def test_completion_removes_tab_from_fancycompleter(monkeypatch_readline):
     def fn():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -3365,6 +3365,28 @@ def test_complete_removes_duplicates_with_coloring(
             else:
                 assert pdb.local.GLOBAL_PDB.fancycompleter.config.use_colors is False
                 assert get_completions("help") == ["help", "helpvar"]
+
+            # Patch readline to return expected results for "p helpvar.".
+            monkeypatch_readline("p helpvar.", 2, 10)
+            if readline_param == "pyrepl":
+                assert pdb.local.GLOBAL_PDB.fancycompleter.config.use_colors is True
+                comps = get_completions("helpvar.")
+                assert type(helpvar.denominator) == int
+                assert any(
+                    re.match(r"\x1b\[\d\d\d;00m\x1b\[33;01mdenominator\x1b\[00m", x)
+                    for x in comps
+                )
+                if all(x.startswith("\x1b") or x == " "
+                       for x in comps):
+                    assert " " in comps
+                else:
+                    assert " " not in comps
+            else:
+                assert pdb.local.GLOBAL_PDB.fancycompleter.config.use_colors is False
+                comps = get_completions("helpvar.")
+                assert "denominator" in comps
+                assert " " not in comps
+
             return True
 
         set_trace()


### PR DESCRIPTION
With "p sys.version" pdb provides completions `["sys.version",
"sys.version_info"]`, but we want to only display `["version",
"version_info"]` then (as with completions from fancycompleter).