### PR TITLE
do_continue: stop if there is an error with do_break

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -1037,7 +1037,10 @@ except for when using the function decorator.
 
     def do_continue(self, arg):
         if arg != '':
+            self._seen_error = False
             self.do_tbreak(arg)
+            if self._seen_error:
+                return 0
         return super(Pdb, self).do_continue('')
     do_continue.__doc__ = pdb.Pdb.do_continue.__doc__
     do_c = do_cont = do_continue
@@ -1597,6 +1600,7 @@ except for when using the function decorator.
 
     def error(self, msg):
         """Override/enhance default error method to display tracebacks."""
+        self._seen_error = msg
         print("***", msg, file=self.stdout)
 
         if not self.config.show_traceback_on_error:

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2885,6 +2885,38 @@ Deleted breakpoint NUM
     ))
 
 
+@pytest.mark.skipif(not hasattr(pdb.pdb.Pdb, "error"),
+                    reason="no error method")
+def test_continue_arg_with_error():
+    def fn():
+        set_trace()
+        x = 1
+        y = 2
+        z = 3
+        return x+y+z
+
+    _, lineno = inspect.getsourcelines(fn)
+    line_z = lineno + 4
+
+    check(fn, r"""
+[NUM] > .*fn()
+-> x = 1
+   5 frames hidden .*
+# c.foo
+\*\*\* The specified object '.foo' is not a function or was not found along sys.path.
+# c {break_lnum}
+Breakpoint NUM at {filename}:{break_lnum}
+Deleted breakpoint NUM
+[NUM] > .*fn()
+-> z = 3
+   5 frames hidden .*
+# c
+    """.format(
+        break_lnum=line_z,
+        filename=__file__,
+    ))
+
+
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="header kwarg is 3.7+")
 def test_set_trace_header():
     """Handler header kwarg added with Python 3.7 in pdb.set_trace."""


### PR DESCRIPTION
It should not continue when using "c.foo" accidentally, and not in
general when the temporary breakpoint could not be set.