### PR TITLE
ci: use .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[coverage:run]
+include = pdb.py, testing/*
+branch = 1
+parallel = 1

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     coverage: pytest-cov
     pexpect
 setenv =
-    coverage: PYTEST_ADDOPTS=--cov --cov-config=tox.ini {env:PYTEST_ADDOPTS:} --cov-report=xml --cov-report=term-missing
+    coverage: PYTEST_ADDOPTS=--cov --cov-report=xml --cov-report=term-missing {env:PYTEST_ADDOPTS:}
 passenv =
     PYTEST_ADDOPTS
 commands = pytest {posargs}
@@ -17,8 +17,3 @@ deps =
     flake8
 commands =
     flake8 pdb.py testing
-
-[coverage:run]
-include = pdb.py, testing/*
-branch = 1
-parallel = 1


### PR DESCRIPTION
This allows for `pytest --cov` without `--cov-config=tox.ini`, which
would otherwise result in the config not being picked up in some case.
Also makes it clearer that coverage is used.