### PR TITLE
Always setup self.stdout for global pdb

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -180,7 +180,7 @@ undefined = Undefined()
 
 
 class PdbMeta(type):
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls, completekey='tab', stdin=None, stdout=None, *args, **kwargs):
         """Reuse an existing instance with ``pdb.set_trace()``."""
         global_pdb = getattr(local, "GLOBAL_PDB", None)
         if global_pdb:
@@ -217,6 +217,8 @@ class PdbMeta(type):
                 sys.settrace(None)
                 global_pdb.set_continue()
                 global_pdb._set_trace_use_next = True
+
+            global_pdb._setup_streams(stdout=stdout)
 
             return global_pdb
 
@@ -288,7 +290,12 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         self.history = []
         self.show_hidden_frames = False
         self.hidden_frames = []
-        self.stdout = self.ensure_file_can_write_unicode(self.stdout)
+        self._setup_streams(stdout=self.stdout)
+
+    def _setup_streams(self, stdout):
+        if stdout is None:
+            stdout = sys.stdout
+        self.stdout = self.ensure_file_can_write_unicode(stdout)
 
     def ensure_file_can_write_unicode(self, f):
         # Wrap with an encoder, but only if not already wrapped

--- a/pdb.py
+++ b/pdb.py
@@ -180,7 +180,7 @@ undefined = Undefined()
 
 
 class PdbMeta(type):
-    def __call__(cls, completekey='tab', stdin=None, stdout=None, *args, **kwargs):
+    def __call__(cls, *args, **kwargs):
         """Reuse an existing instance with ``pdb.set_trace()``."""
         global_pdb = getattr(local, "GLOBAL_PDB", None)
         if global_pdb:
@@ -218,6 +218,10 @@ class PdbMeta(type):
                 global_pdb.set_continue()
                 global_pdb._set_trace_use_next = True
 
+            try:
+                stdout = args[2]
+            except IndexError:
+                stdout = kwargs.get("stdout", sys.stdout)
             global_pdb._setup_streams(stdout=stdout)
 
             return global_pdb
@@ -293,8 +297,6 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         self._setup_streams(stdout=self.stdout)
 
     def _setup_streams(self, stdout):
-        if stdout is None:
-            stdout = sys.stdout
         self.stdout = self.ensure_file_can_write_unicode(stdout)
 
     def ensure_file_can_write_unicode(self, f):

--- a/pdb.py
+++ b/pdb.py
@@ -180,7 +180,7 @@ undefined = Undefined()
 
 
 class PdbMeta(type):
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls, completekey='tab', stdin=None, stdout=None, *args, **kwargs):
         """Reuse an existing instance with ``pdb.set_trace()``."""
         global_pdb = getattr(local, "GLOBAL_PDB", None)
         if global_pdb:
@@ -218,10 +218,8 @@ class PdbMeta(type):
                 global_pdb.set_continue()
                 global_pdb._set_trace_use_next = True
 
-            try:
-                stdout = args[2]
-            except IndexError:
-                stdout = kwargs.get("stdout", sys.stdout)
+            if stdout is None:
+                stdout = sys.stdout
             global_pdb._setup_streams(stdout=stdout)
 
             return global_pdb
@@ -247,7 +245,7 @@ class PdbMeta(type):
         else:
             set_global_pdb = use_global_pdb
         local._pdbpp_in_init = True
-        obj.__init__(*args, **kwargs)
+        obj.__init__(completekey, stdin, stdout, *args, **kwargs)
         local._pdbpp_in_init = False
         if set_global_pdb:
             local.GLOBAL_PDB = obj

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -4708,3 +4708,27 @@ do_help
 ])
 def test_truncate_to_visible_length(s, maxlength, expected):
     assert pdb.Pdb._truncate_to_visible_length(s, maxlength) == expected
+
+
+def test_stdout_reconfigured(monkeypatch):
+    """Check that self.stdout is re-configured with global pdb."""
+    def fn():
+        import io
+
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        print("ignored")
+        set_trace()
+        sys.stdout.close()
+        sys.stdout = old_stdout
+        set_trace(cleanup=False)
+        sys.stdout.write('# c')  # Hack to reflect output in test.
+        return
+
+    check(fn, """
+[NUM] > .*fn()
+-> sys.stdout.write('# c')
+   5 frames hidden .*
+# c
+# c
+""")

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -4714,10 +4714,14 @@ def test_truncate_to_visible_length(s, maxlength, expected):
 def test_stdout_reconfigured(pass_stdout, monkeypatch):
     """Check that self.stdout is re-configured with global pdb."""
     def fn():
-        import io
         import sys
+        if sys.version_info > (3,):
+            from io import StringIO
+        else:
+            from StringIO import StringIO
 
-        patched_stdout = io.StringIO()
+        patched_stdout = StringIO()
+
         with monkeypatch.context() as mp:
             mp.setattr(sys, "stdout", patched_stdout)
 


### PR DESCRIPTION
Fixes "ValueError: I/O operation on closed file" when e.g. pytest might
have reconfigured it.