### PR TITLE
Do not re-use global pdb with different $HOME

### DIFF
--- a/src/pdb.py
+++ b/src/pdb.py
@@ -221,7 +221,6 @@ class PdbMeta(type):
                 hasattr(global_pdb, "_force_use_as_global_pdb")
                 or cls.use_global_pdb_for_class(global_pdb, cls)
             )
-            and os.environ.get("HOME") == global_pdb._env["HOME"]
         ):
             if hasattr(global_pdb, "botframe"):
                 # Do not stop while tracing is active (in _set_stopinfo).
@@ -258,6 +257,9 @@ class PdbMeta(type):
 
     @classmethod
     def use_global_pdb_for_class(cls, obj, C):
+        _env = getattr(obj, "_env", None)
+        if _env is not None and _env.get("HOME") != os.environ.get("HOME"):
+            return False
         if type(obj) == C:
             return True
         if getattr(obj, "_use_global_pdb_for_class", None) == C:

--- a/src/pdb.py
+++ b/src/pdb.py
@@ -205,7 +205,7 @@ class PdbMeta(type):
                 "use_global_pdb",
                 (
                     not global_pdb._in_interaction
-                    and int(os.environ.get("PDBPP_REUSE_GLOBAL_PDB", 1))
+                    and os.environ.get("PDBPP_REUSE_GLOBAL_PDB", "1") == "1"
                 ),
             )
         else:

--- a/src/pdb.py
+++ b/src/pdb.py
@@ -221,7 +221,7 @@ class PdbMeta(type):
                 hasattr(global_pdb, "_force_use_as_global_pdb")
                 or cls.use_global_pdb_for_class(global_pdb, cls)
             )
-            and os.environ["HOME"] == global_pdb._env["HOME"]
+            and os.environ.get("HOME") == global_pdb._env["HOME"]
         ):
             if hasattr(global_pdb, "botframe"):
                 # Do not stop while tracing is active (in _set_stopinfo).
@@ -251,7 +251,7 @@ class PdbMeta(type):
             set_global_pdb = use_global_pdb
         obj.__init__(*args, **kwargs)
         if set_global_pdb:
-            obj._env = {"HOME": os.environ["HOME"]}
+            obj._env = {"HOME": os.environ.get("HOME")}
             local.GLOBAL_PDB = obj
         local._pdbpp_in_init = False
         return obj

--- a/src/pdb.py
+++ b/src/pdb.py
@@ -202,7 +202,11 @@ class PdbMeta(type):
         global_pdb = getattr(local, "GLOBAL_PDB", None)
         if global_pdb:
             use_global_pdb = kwargs.pop(
-                "use_global_pdb", not global_pdb._in_interaction
+                "use_global_pdb",
+                (
+                    not global_pdb._in_interaction
+                    and int(os.environ.get("PDBPP_REUSE_GLOBAL_PDB", 1))
+                ),
             )
         else:
             use_global_pdb = kwargs.pop("use_global_pdb", True)
@@ -217,6 +221,7 @@ class PdbMeta(type):
                 hasattr(global_pdb, "_force_use_as_global_pdb")
                 or cls.use_global_pdb_for_class(global_pdb, cls)
             )
+            and os.environ["HOME"] == global_pdb._env["HOME"]
         ):
             if hasattr(global_pdb, "botframe"):
                 # Do not stop while tracing is active (in _set_stopinfo).
@@ -246,6 +251,7 @@ class PdbMeta(type):
             set_global_pdb = use_global_pdb
         obj.__init__(*args, **kwargs)
         if set_global_pdb:
+            obj._env = {"HOME": os.environ["HOME"]}
             local.GLOBAL_PDB = obj
         local._pdbpp_in_init = False
         return obj

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -861,6 +861,27 @@ new_set_trace
 """)
 
 
+def test_global_pdb_not_reused_with_different_home(
+    monkeypatch_pdb_methods, monkeypatch
+):
+    def fn():
+        set_trace()
+        first = pdb.local.GLOBAL_PDB
+
+        set_trace(cleanup=False)
+        assert first is pdb.local.GLOBAL_PDB
+
+        monkeypatch.setenv("HOME", "something else")
+        set_trace(cleanup=False)
+        assert first is not pdb.local.GLOBAL_PDB
+
+    check(fn, """
+=== set_trace
+=== set_trace
+=== set_trace
+""")
+
+
 def test_single_question_mark():
     def fn():
         def f2(x, y):

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -256,7 +256,10 @@ class InnerTestException(Exception):
 
 def check(func, expected):
     expected, lines = run_func(func, expected)
-    maxlen = max(map(len, expected))
+    if expected:
+        maxlen = max(map(len, expected))
+    else:
+        maxlen = 0
     all_ok = True
     print()
     for pattern, string in zip_longest(expected, lines):


### PR DESCRIPTION
This works around pytest initializing it already with a mocked `$HOME`,
resulting in user config not being loaded later.