### PR TITLE
Windows support

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1978,21 +1978,6 @@ except for when using the function decorator.
             # Work around above returning width, height = 0, 0 in Emacs
             width = width if width != 0 else fallback[0]
             height = height if height != 0 else fallback[1]
-
-            # Hack to remove the linewrap. Not sure why it happens...
-            # During a sticky, the current line looks like so (vertical bars
-            # denote the edge of the cmd/powershell window):
-            #   | 2         import pdb; pdb.set_trace()     |
-            #   | 3  ->     a = 1                           |
-            #   |                                           |
-            #   | 4         b = 2                           |
-            # Simply resizing the terminal a little wider results in:
-            #   | 2         import pdb; pdb.set_trace()      |
-            #   | 3  ->     a = 1                            |
-            #   | 4         b = 2                            |
-            # So I figure we just fake the terminal size a bit. /shrug.
-            if has_colorama_on_windows:
-                width -= 1
             return width, height
         else:
             return get_terminal_size(fallback)

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -361,6 +361,10 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
     _in_interaction = False
 
     def __init__(self, *args, **kwds):
+        if has_colorama_on_windows:
+            # Do not strip the ANSI codes - they don't do anything on Windows
+            # and stripping them would mean updating many tests.
+            colorama.init(strip=False)
         self.ConfigFactory = kwds.pop('Config', None)
         self.start_lineno = kwds.pop('start_lineno', None)
         self.start_filename = kwds.pop('start_filename', None)

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -68,9 +68,6 @@ except ImportError:
 
         return dec
 
-has_colorama_on_windows = False
-
-
 # If it contains only _, digits, letters, [] or dots, it's probably side
 # effects free.
 side_effects_free = re.compile(r'^ *[_0-9a-zA-Z\[\].]* *$')
@@ -376,7 +373,6 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         if sys.platform == "win32":
             try:
                 import colorama
-                has_colorama_on_windows = True
                 # Do not strip the ANSI codes - they don't do anything on Windows
                 # and stripping them would mean updating many tests.
                 colorama.init(strip=False)

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -170,6 +170,10 @@ class DefaultConfig(object):
     line_number_color = Color.turquoise
     filename_color = Color.yellow
     current_line_color = "39;49;7"  # default fg, bg, inversed
+    # Windows/colorama doesn't support 'inversed', so instead of using the
+    # terminal default colors, we just use black-on-white
+    if sys.platform == "win32":
+        current_line_color = "30;47"  # black, white
 
     show_traceback_on_error = True
     show_traceback_on_error_limit = None

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1976,6 +1976,21 @@ except for when using the function decorator.
             # Work around above returning width, height = 0, 0 in Emacs
             width = width if width != 0 else fallback[0]
             height = height if height != 0 else fallback[1]
+
+            # Hack to remove the linewrap. Not sure why it happens...
+            # During a sticky, the current line looks like so (vertical bars
+            # denote the edge of the cmd/powershell window):
+            #   | 2         import pdb; pdb.set_trace()     |
+            #   | 3  ->     a = 1                           |
+            #   |                                           |
+            #   | 4         b = 2                           |
+            # Simply resizing the terminal a little wider results in:
+            #   | 2         import pdb; pdb.set_trace()      |
+            #   | 3  ->     a = 1                            |
+            #   | 4         b = 2                            |
+            # So I figure we just fake the terminal size a bit. /shrug.
+            if has_colorama_on_windows:
+                width -= 1
             return width, height
         else:
             return get_terminal_size(fallback)

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -69,13 +69,6 @@ except ImportError:
         return dec
 
 has_colorama_on_windows = False
-if sys.platform == "win32":
-    try:
-        import colorama
-        has_colorama_on_windows = True
-    except ImportError:
-        # No windows support. Do we want to stop trying all coloring?
-        print("Please install 'colorama' for color support on Windows.")
 
 
 # If it contains only _, digits, letters, [] or dots, it's probably side
@@ -365,10 +358,6 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
     _in_interaction = False
 
     def __init__(self, *args, **kwds):
-        if has_colorama_on_windows:
-            # Do not strip the ANSI codes - they don't do anything on Windows
-            # and stripping them would mean updating many tests.
-            colorama.init(strip=False)
         self.ConfigFactory = kwds.pop('Config', None)
         self.start_lineno = kwds.pop('start_lineno', None)
         self.start_filename = kwds.pop('start_filename', None)
@@ -384,6 +373,15 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             self._disable_pytest_capture_maybe()
         kwargs = self.config.default_pdb_kwargs.copy()
         kwargs.update(**kwds)
+        if sys.platform == "win32":
+            try:
+                import colorama
+                has_colorama_on_windows = True
+                # Do not strip the ANSI codes - they don't do anything on Windows
+                # and stripping them would mean updating many tests.
+                colorama.init(strip=False)
+            except ImportError:
+                print("Please install 'colorama' for color support on Windows.")
         super(Pdb, self).__init__(*args, **kwargs)
         self.prompt = self.config.prompt
         self.display_list = {}  # frame --> (name --> last seen value)

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -68,6 +68,16 @@ except ImportError:
 
         return dec
 
+has_colorama_on_windows = False
+if sys.platform == "win32":
+    try:
+        import colorama
+        has_colorama_on_windows = True
+    except ImportError:
+        # No windows support. Do we want to stop trying all coloring?
+        print("Please install 'colorama' for color support on Windows.")
+
+
 # If it contains only _, digits, letters, [] or dots, it's probably side
 # effects free.
 side_effects_free = re.compile(r'^ *[_0-9a-zA-Z\[\].]* *$')

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1766,6 +1766,40 @@ NUM +->         ^[[38;5;28;01mreturn^[[39;00m a
 """.format(line_num=fn.__code__.co_firstlineno - 1))  # noqa: E501
 
 
+def test_truncated_source_with_highlight():
+
+    def fn():
+        """some docstring longer than maxlength for truncate_long_lines, which is 80"""
+        a = 1
+        set_trace(Config=ConfigWithHighlight)
+
+        return a
+
+    check(fn, """
+[NUM] > .*fn()
+-> return a
+   5 frames hidden .*
+# l {line_num}, 5
+<COLORNUM> +\t$
+<COLORNUM> +\t    def fn():
+<COLORNUM> +\t        \"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"
+<COLORNUM> +\t        a = 1
+<COLORNUM> +\t        set_trace(Config=ConfigWithHighlight)
+<COLORNUM> +\t$
+# sticky
+<CLEARSCREEN>
+[NUM] > .*fn(), 5 frames hidden
+
+<COLORNUM> +       def fn():
+<COLORNUM> +           \"\"\"some docstring longer than maxlength for truncate_long_lines
+<COLORNUM> +           a = 1
+<COLORNUM> +           set_trace(Config=ConfigWithHighlight)
+<COLORNUM> +$
+<COLORCURLINE> +->         return a                                                       <COLORRESET>
+# c
+""".format(line_num=fn.__code__.co_firstlineno - 1))  # noqa: E501
+
+
 def test_truncated_source_with_pygments_and_highlight():
 
     def fn():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -236,6 +236,8 @@ def extract_commands(lines):
     return cmds
 
 
+COLORCURLINE_START = r'\^\[\[44m\^\[\[36;01;44m'
+COLORCURLINE = COLORCURLINE_START + r' *[0-9]+\^\[\[00;44m'
 shortcuts = [
     ('[', '\\['),
     (']', '\\]'),
@@ -244,11 +246,11 @@ shortcuts = [
     ('^', '\\^'),
     (r'\(Pdb++\) ', r'\(Pdb\+\+\) '),
     (r'\(com++\) ', r'\(com\+\+\) '),
-    ('<COLORCURLINE>', r'\^\[\[44m\^\[\[36;01;44m *[0-9]+\^\[\[00;44m'),
+    ('<COLORCURLINE>', COLORCURLINE),
     ('<COLORNUM>', r'\^\[\[36;01m *[0-9]+\^\[\[00m'),
     ('<COLORFNAME>', r'\^\[\[33;01m'),
     ('<COLORLNUM>', r'\^\[\[36;01m'),
-    ('<COLORRESET>', r'\^\[\[00m'),
+    ('<COLORRESET>', r'\^\[\[0{1,2}m'),
     ('<PYGMENTSRESET>', r'\^\[\[39[^m]*m'),
     ('NUM', ' *[0-9]+'),
     # Optional message with Python 2.7 (e.g. "--Return--"), not using Pdb.message.
@@ -1793,7 +1795,7 @@ def test_truncated_source_with_pygments_and_highlight():
 <COLORNUM> +           a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 <COLORNUM> +           set_trace(Config^[[38;5;241m=^[[39mConfigWithPygmentsAndHighlight)
 <COLORNUM> +$
-<COLORCURLINE> +->         ^[[38;5;28;01;44mreturn<PYGMENTSRESET> a                                                       ^[[00m
+<COLORCURLINE> +->         ^[[38;5;28;01;44mreturn<PYGMENTSRESET> a                                                       <COLORRESET>
 # c
 """.format(line_num=fn.__code__.co_firstlineno - 1))  # noqa: E501
 
@@ -2056,7 +2058,7 @@ def test_longlist_with_highlight():
 <COLORNUM>         def fn():
 <COLORNUM>             a = 1
 <COLORNUM>             set_trace(Config=ConfigWithHighlight)
-<COLORCURLINE> +->         return a                                                       ^[[00m$
+<COLORCURLINE> +->         return a                                                       <COLORRESET>
 # c
 """)  # noqa: E501
 
@@ -2584,7 +2586,7 @@ def test_sticky_dunder_return_with_highlight():
 
     colored_cur_lines = [
         x for x in lines
-        if x.startswith('^[[44m^[[36;01;44m') and '->' in x
+        if re.match(COLORCURLINE_START, x) is not None and '->' in x
     ]
     assert len(colored_cur_lines) == 2
 


### PR DESCRIPTION
This adds Windows support via [`colorama`](https://pypi.org/project/colorama/).

Fixes #270.

Includes #338. This PR should be rebased once that one is squashed and merged.

##Notes:

Due to the way `colorama` works - injecting win32 calls - I'm not sure if there's a way to test that colors are *actually* displayed. Had I opted to have `colorama` strip the ANSI codes, I could have used that to test that it's working. However, that would have meant updating the regex in at least 31 tests.


## Example:

```python
def fn():
    import pdb; pdb.set_trace()
    a = 1
    b = 2
    c = 3
    return a+b+c

fn()
```


### Before (v0.10.2)

#### Windows CMD
![image](https://user-images.githubusercontent.com/5386897/69499079-67135600-0ea3-11ea-8316-a95dce02537a.png)

#### PowerShell
![image](https://user-images.githubusercontent.com/5386897/69499109-af327880-0ea3-11ea-91ea-d65321112677.png)


### After

#### Windows CMD
![image](https://user-images.githubusercontent.com/5386897/69483788-8f864c00-0de0-11ea-94ce-4df709e82c1c.png)

![image](https://user-images.githubusercontent.com/5386897/69499437-fd954680-0ea6-11ea-94cc-0feaf34de15f.png)


#### PowerShell
![image](https://user-images.githubusercontent.com/5386897/69499147-f0c32380-0ea3-11ea-937f-b45c6882a64b.png)

![image](https://user-images.githubusercontent.com/5386897/69499153-046e8a00-0ea4-11ea-9503-a033ff572f04.png)

![image](https://user-images.githubusercontent.com/5386897/69499429-dd658780-0ea6-11ea-8c27-47034ea90088.png)



## Questions:


### `t_windows.py`

In blueyed/pdbpp@win2, you had a `t_windows.py` file. This appears to just be messing around with colorama - is that something you want to keep?


### `_setup_streams()`

Also in blueyed/pdbpp@win2, there was a `Pdb._setup_streams()` method:

```
def _setup_streams(self, stdout):
    self.stdout = self.ensure_file_can_write_unicode(stdout)

    if os.name == 'nt':
        try:
            import colorama
            supports_color = True
        except ImportError:
            supports_color = False
    else:
        supports_color = True

    # Setup highlight/use_pygments for detected color support.
    if self.config.highlight is None or self.config.use_pygments is None:
        if self.config.highlight is None:
            self.config.highlight = supports_color

    if os.name == "nt" and supports_color:
        if self.config.highlight or self.config.use_pygments is not False:
            self.stdout = colorama.AnsiToWin32(
                self.stdout, convert=True, strip=True
            ).stream
```

Do you want me to keep this for any reason? It's not needed for Windows support but you may have a refactoring in mind that I'm not aware of.


### Blink and Reveal in expected regex?

I'm failing `test_truncated_source_with_pygments_and_highlight`. It appears there's some wrapping around the `return` statement in the expected regex:

```
\^\[\[38;5;28;01;44mreturn\^\[\[39;00;44m
```

Those [ANSI codes](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters) are
```
38: set foreground
5: slow blink
28: reveal
01: bold
44: background blue

39: default foreground
00: reset all
44: background blue
```

I don't understand why "slow blink" and "reveal" codes are in there. Are they added from pygments or something?

#### Failed Test Details

```
# Expected Regex:
\^\[\[30m\^\[\[47m *[0-9]+ +->         \^\[\[38;5;28;01;44mreturn\^\[\[39;00;44m a                                                       \^\[\[0{1,2}m
# Actual line:
^[[30m^[[47m1607  ->         return a                                                       ^[[0m
```
