### PR TITLE
Make pdbpp.Pdb.prompt a property

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -354,7 +354,9 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
     def prompt(self, value):
         """Ensure there is "++" in the prompt always."""
         if "++" not in value:
-            value = re.sub(r"(\w)(\s*\W\s*)?$", r"\1++\2", value)
+            m = re.match(r"^(.*\w)(\s*\W\s*)?$", value)
+            if m:
+                value = "{}++{}".format(*m.groups(""))
         self._prompt = value
 
     def _setup_streams(self, stdout):

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -346,6 +346,17 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         self.hidden_frames = []
         self._setup_streams(stdout=self.stdout)
 
+    @property
+    def prompt(self):
+        return self._prompt
+
+    @prompt.setter
+    def prompt(self, value):
+        """Ensure there is "++" in the prompt always."""
+        if "++" not in value:
+            value = re.sub(r"(\w)(\s*\W\s*)?$", r"\1++\2", value)
+        self._prompt = value
+
     def _setup_streams(self, stdout):
         self.stdout = self.ensure_file_can_write_unicode(stdout)
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -302,6 +302,9 @@ def test_prompt_setter():
     assert p.prompt == "custom++  "
     p.prompt = ""
     assert p.prompt == ""
+    # Not changed (also used in tests).
+    p.prompt = "# "
+    assert p.prompt == "# "
     # Can be forced.
     p._prompt = "custom"
     assert p.prompt == "custom"

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -282,6 +282,31 @@ def check(func, expected):
     assert all_ok
 
 
+def test_prompt_setter():
+    from pdb import Pdb
+
+    p = Pdb()
+    assert p.prompt == "(Pdb++) "
+
+    p.prompt = "(Pdb)"
+    assert p.prompt == "(Pdb++)"
+    p.prompt = "ipdb> "
+    assert p.prompt == "ipdb++> "
+    p.prompt = "custom"
+    assert p.prompt == "custom++"
+    p.prompt = "custom "
+    assert p.prompt == "custom++ "
+    p.prompt = "custom :"
+    assert p.prompt == "custom++ :"
+    p.prompt = "custom  "
+    assert p.prompt == "custom++  "
+    p.prompt = ""
+    assert p.prompt == ""
+    # Can be forced.
+    p._prompt = "custom"
+    assert p.prompt == "custom"
+
+
 def test_config_pygments(monkeypatch):
     from pdb import DefaultConfig, Pdb
     import pygments.formatters


### PR DESCRIPTION
This is useful for when using e.g.
[ipdb](https://github.com/gotcha/ipdb) / IPython's debugger, where
`prompt = 'ipdb> '` is used to indicate that pdb++ is used on top.