### PR TITLE
ci: Travis: separate jobs per Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,13 @@ stages:
 jobs:
   include:
     - name: 'py37 (osx)'
-      python: 3.7
       os: osx
       osx_image: xcode10.2
       env: TOXENV=py37-coverage
+      before_install:
+        - ln -sfn "$(which python3)" /usr/local/bin/python
+        - python -V
+        - test $(python -c 'import sys; print("%d%d" % sys.version_info[0:2])') = 37
 
     - name: 'py38'
       env: TOXENV=py38-coverage
@@ -29,7 +32,7 @@ jobs:
       env: TOXENV=py37-coverage
       python: 3.7
     - name: 'py36'
-      env: TOXENV=ppy36-coverage
+      env: TOXENV=py36-coverage
       python: 3.6
     - name: 'py35'
       env: TOXENV=py35-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
     - name: 'py37 (osx)'
       os: osx
       osx_image: xcode10.2
+      language: generic
       env: TOXENV=py37-coverage
       before_install:
         - ln -sfn "$(which python3)" /usr/local/bin/python

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,20 +25,32 @@ jobs:
         - python -V
         - test $(python -c 'import sys; print("%d%d" % sys.version_info[0:2])') = 37
 
-    - name: 'py36 + py35 + py34 + py27'
-      env:
-        - TOXENV=py34-coverage,py35-coverage,py36-coverage,py27-coverage
-        - INSTALL_PYTHON="python-3.5 python-3.4"
+    - name: 'py38'
+      env: TOXENV=py38-coverage
+      python: 3.8
+    - name: 'py37'
+      env: TOXENV=py37-coverage
+      python: 3.7
+    - name: 'py36'
+      env: TOXENV=ppy36-coverage
+      python: 3.6
+    - name: 'py35'
+      env: TOXENV=py35-coverage
+      python: 3.5
+    - name: 'py34'
+      env: TOXENV=py34-coverage
+      python: 3.4
 
-    - name: 'py38 + py37'
-      env:
-        - TOXENV=py38-coverage,py37-coverage
-        - INSTALL_PYTHON="python-3.8"
+    - name: 'py27'
+      env: TOXENV=py27-coverage
+      python: 2.7
 
-    - name: 'pypy3 + pypy'
-      env:
-        - TOXENV=pypy3-coverage,pypy-coverage
-        - INSTALL_PYTHON="pypy pypy3"
+    - name: 'pypy3'
+      env: TOXENV=pypy3-coverage
+      python: pypy3
+    - name: 'pypy'
+      env: TOXENV=pypy-coverage
+      python: pypy
 
     - name: 'checkqa'
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: xenial
-language: generic
+language: python
 cache: false
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,10 @@ stages:
 jobs:
   include:
     - name: 'py37 (osx)'
+      python: 3.7
       os: osx
       osx_image: xcode10.2
       env: TOXENV=py37-coverage
-      before_install:
-        - ln -sfn "$(which python3)" /usr/local/bin/python
-        - python -V
-        - test $(python -c 'import sys; print("%d%d" % sys.version_info[0:2])') = 37
 
     - name: 'py38'
       env: TOXENV=py38-coverage


### PR DESCRIPTION
Reverts the over-optimization from 43b0143 to have an better overview in case of failures.