### PR TITLE
Improve sticky mode

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -41,6 +41,14 @@ except ImportError:
         def signature(obj):
             return ' [pip install funcsigs to show the signature]'
 
+try:
+    from functools import lru_cache
+except ImportError:
+    def lru_cache(*_, **__):
+        def dec(fn):
+            return fn
+
+        return dec
 
 # If it contains only _, digits, letters, [] or dots, it's probably side
 # effects free.
@@ -337,9 +345,14 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         super(Pdb, self).__init__(*args, **kwargs)
         self.prompt = self.config.prompt
         self.display_list = {}  # frame --> (name --> last seen value)
+
         self.sticky = self.config.sticky_by_default
         self.first_time_sticky = self.sticky
         self.sticky_ranges = {}  # frame --> (start, end)
+        self._sticky_messages = []  # Message queue for sticky mode.
+        self._sticky_last_frame = None
+        self._sticky_skip_cls = False
+
         self.tb_lineno = {}  # frame --> lineno where the exception raised
         self.history = []
         self.show_hidden_frames = False
@@ -412,8 +425,9 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             return
         if self.config.exec_if_unfocused:
             self.exec_if_unfocused()
-        self.print_stack_entry(self.stack[self.curindex])
-        self.print_hidden_frames_count()
+        if not self.sticky:
+            self.print_stack_entry(self.stack[self.curindex])
+            self.print_hidden_frames_count()
 
         with self._custom_completer():
             self.config.before_interaction_hook(self)
@@ -424,6 +438,36 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
                 self.cmdloop()
 
         self.forget()
+
+    def _sticky_handle_cls(self):
+        if not self._sticky_skip_cls:
+            self.stdout.write(CLEARSCREEN)
+            self.stdout.flush()
+            self._sticky_last_frame = None
+
+    def postcmd(self, stop, line):
+        """Handle clearing of the screen for sticky mode."""
+        stop = super(Pdb, self).postcmd(stop, line)
+        if self.sticky:
+            if stop:
+                self._sticky_handle_cls()
+            else:
+                if self._sticky_messages:
+                    for msg in self._sticky_messages:
+                        print(msg, file=self.stdout)
+                    self._sticky_messages = []
+                self._sticky_last_frame = self.stack[self.curindex]
+        return stop
+
+    def set_continue(self):
+        if self.sticky:
+            self._sticky_skip_cls = True
+        super(Pdb, self).set_continue()
+
+    def set_quit(self):
+        if self.sticky:
+            self._sticky_skip_cls = True
+        super(Pdb, self).set_quit()
 
     @contextlib.contextmanager
     def _custom_completer(self):
@@ -757,6 +801,10 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         src = self.try_to_decode(src)
         return self._highlight(src)
 
+    @lru_cache(maxsize=64)
+    def _highlight_cached(self, src):
+        return self._highlight(src)
+
     def _format_line(self, lineno, marker, line, lineno_width):
         lineno = ('%%%dd' % lineno_width) % lineno
         if self.config.highlight:
@@ -1019,7 +1067,7 @@ except for when using the function decorator.
 
     do_ll = do_longlist
 
-    def _printlonglist(self, linerange=None):
+    def _printlonglist(self, linerange=None, only_visible=False):
         try:
             if self.curframe.f_code.co_name == '<module>':
                 # inspect.getsourcelines is buggy in this case: if we just
@@ -1044,7 +1092,7 @@ except for when using the function decorator.
             end = min(end, lineno+len(lines))
             lines = lines[start-lineno:end-lineno]
             lineno = start
-        self._print_lines_pdbpp(lines, lineno)
+        self._print_lines_pdbpp(lines, lineno, only_visible=only_visible)
 
     @staticmethod
     def _truncate_to_visible_length(s, maxlength):
@@ -1081,7 +1129,7 @@ except for when using the function decorator.
         assert len(RE_COLOR_ESCAPES.sub("", ret)) <= maxlength
         return ret
 
-    def _print_lines_pdbpp(self, lines, lineno, print_markers=True):
+    def _print_lines_pdbpp(self, lines, lineno, print_markers=True, only_visible=False):
         lines = [line[:-1] for line in lines]  # remove the trailing '\n'
         lines = [line.replace('\t', '    ')
                  for line in lines]  # force tabs to 4 spaces
@@ -1095,8 +1143,6 @@ except for when using the function decorator.
             maxlength = max(width - 9, 16)
             lines = [self._truncate_to_visible_length(line, maxlength)
                      for line in lines]
-        else:
-            maxlength = max(map(len, lines))
 
         if print_markers:
             exc_lineno = self.tb_lineno.get(self.curframe, None)
@@ -1109,6 +1155,16 @@ except for when using the function decorator.
                     if len(lines) > maxlines:
                         lines = lines[:maxlines]
                         lines.append('...')
+
+        if only_visible:
+            # Arrange for prompt and 2 lines on top (location + newline).
+            # Keep an empty line at the end (after prompt), so that any output
+            # shows up at the top.
+            max_lines = height - 1 - 3
+            if len(lines) > max_lines:
+                cutoff = max_lines - len(lines)
+                lines = lines[0 - max_lines:]
+                lineno -= cutoff
 
         lineno_width = len(str(lineno + len(lines)))
         if print_markers:
@@ -1382,17 +1438,33 @@ except for when using the function decorator.
 
     def _print_if_sticky(self):
         if self.sticky:
-            if self.first_time_sticky:
-                self.first_time_sticky = False
-            else:
-                self.stdout.write(CLEARSCREEN)
             frame, lineno = self.stack[self.curindex]
-            filename = self.canonic(frame.f_code.co_filename)
-            s = '> %s(%r)' % (filename, lineno)
+            if self._sticky_last_frame and frame != self._sticky_last_frame:
+                self._sticky_handle_cls()
+            stack_entry = self._get_formatted_stack_entry(
+                self.stack[self.curindex], "CUTOFF"
+            )
+            s = stack_entry.split("CUTOFF")[0]
+            if self._sticky_messages:
+                for msg in self._sticky_messages:
+                    if msg == "--Return--" and "__return__" in frame.f_locals:
+                        # Handled below.
+                        continue
+                    if msg.startswith("--") and msg.endswith("--"):
+                        s += ", {}".format(msg)
+                    else:
+                        print(msg, file=self.stdout)
+                self._sticky_messages = []
+
+            if self.config.show_hidden_frames_count:
+                n = len(self.hidden_frames)
+                if n:
+                    plural = n > 1 and "s" or ""
+                    s += ", %d frame%s hidden" % (n, plural)
             print(s, file=self.stdout)
             print(file=self.stdout)
             sticky_range = self.sticky_ranges.get(self.curframe, None)
-            self._printlonglist(sticky_range)
+            self._printlonglist(sticky_range, only_visible=True)
 
             if '__exception__' in frame.f_locals:
                 s = self._format_exc_for_sticky(frame.f_locals['__exception__'])
@@ -1451,8 +1523,9 @@ except for when using the function decorator.
 
         If ``start`` and ``end`` are given, sticky mode is enabled and
         only lines within that range (extremes included) will be
-        displayed.
+        displayed (for the current frame).
         """
+        was_sticky = self.sticky
         if arg:
             try:
                 start, end = map(int, arg.split())
@@ -1465,6 +1538,8 @@ except for when using the function decorator.
         else:
             self.sticky = not self.sticky
             self.sticky_range = None
+        if not was_sticky and self.sticky:
+            self._sticky_handle_cls()
         self._print_if_sticky()
 
     def print_stack_trace(self):
@@ -1475,6 +1550,14 @@ except for when using the function decorator.
             pass
 
     def print_stack_entry(
+        self, frame_lineno, prompt_prefix=pdb.line_prefix, frame_index=None
+    ):
+        print(
+            self._get_formatted_stack_entry(frame_lineno, prompt_prefix, frame_index),
+            file=self.stdout,
+        )
+
+    def _get_formatted_stack_entry(
         self, frame_lineno, prompt_prefix=pdb.line_prefix, frame_index=None
     ):
         frame, lineno = frame_lineno
@@ -1497,9 +1580,9 @@ except for when using the function decorator.
         frame_prefix = ("[%%%dd] " % frame_prefix_width) % frame_index
 
         marker_frameno = fmt.format(marker=marker, frame_prefix=frame_prefix)
-        print(marker_frameno, file=self.stdout, end="")
-
-        print(self.format_stack_entry(frame_lineno, lprefix), file=self.stdout)
+        ret = marker_frameno
+        ret += self.format_stack_entry(frame_lineno, lprefix)
+        return ret
 
     def print_current_stack_entry(self):
         if self.sticky:
@@ -1507,15 +1590,8 @@ except for when using the function decorator.
         else:
             self.print_stack_entry(self.stack[self.curindex])
 
-    def user_exception(self, frame, exc_info):
-        self._skip_sticky = True
-        return super(Pdb, self).user_exception(frame, exc_info)
-
     def preloop(self):
-        if getattr(self, "_skip_sticky", False):
-            del self._skip_sticky
-        else:
-            self._print_if_sticky()
+        self._print_if_sticky()
 
         display_list = self._get_display_list()
         for expr, oldvalue in display_list.items():
@@ -1823,10 +1899,11 @@ except for when using the function decorator.
             return False
         return super(Pdb, self).is_skipped_module(module_name)
 
-    if not hasattr(pdb.Pdb, 'message'):  # For py27.
-
-        def message(self, msg):
-            print(msg, file=self.stdout)
+    def message(self, msg):
+        if self.sticky:
+            self._sticky_messages.append(msg)
+            return
+        print(msg, file=self.stdout)
 
     def error(self, msg):
         """Override/enhance default error method to display tracebacks."""

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -233,6 +233,7 @@ shortcuts = [
     ('^', '\\^'),
     ('<COLORCURLINE>', r'\^\[\[44m\^\[\[36;01;44m *[0-9]+\^\[\[00;44m'),
     ('<COLORNUM>', r'\^\[\[36;01m *[0-9]+\^\[\[00m'),
+    ('<COLORFNAME>', r'\^\[\[33;01m'),
     ('<COLORLNUM>', r'\^\[\[36;01m'),
     ('<COLORRESET>', r'\^\[\[00m'),
     ('NUM', ' *[0-9]+'),
@@ -1241,14 +1242,14 @@ def test_up_down_sticky():
    5 frames hidden .*
 # sticky
 <CLEARSCREEN>
-> .*
+[NUM] > .*b(), 5 frames hidden
 
 NUM         def b():
 NUM             set_trace()
 NUM  ->         return
 # up
 <CLEARSCREEN>
-> .*
+[NUM] > .*a(), 5 frames hidden
 
 NUM         def a()
 NUM  ->         b()
@@ -1626,7 +1627,7 @@ NUM +\t        set_trace(Config^[[38;5;241m=^[[39mConfigWithPygments)
 NUM +\t$
 # sticky
 <CLEARSCREEN>
->.*
+[NUM] > .*fn(), 5 frames hidden
 
 NUM +       ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
 NUM +           ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines^[[39.*m
@@ -1660,7 +1661,7 @@ def test_truncated_source_with_pygments_and_highlight():
 <COLORNUM> +\t$
 # sticky
 <CLEARSCREEN>
->.*
+[NUM] > .*fn(), 5 frames hidden
 
 <COLORNUM> +       ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
 <COLORNUM> +           ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines^[[39.*m
@@ -1877,7 +1878,7 @@ def test_sticky():
    5 frames hidden .*
 # sticky
 <CLEARSCREEN>
->.*
+[NUM] > .*fn(), 5 frames hidden
 
 NUM         def fn():
 NUM             set_trace()
@@ -1886,11 +1887,8 @@ NUM             b = 2
 NUM             c = 3
 NUM             return a
 # n
-[NUM] > .*fn()
--> b = 2
-   5 frames hidden .*
 <CLEARSCREEN>
->.*
+[NUM] > .*fn(), 5 frames hidden
 
 NUM         def fn():
 NUM             set_trace()
@@ -1924,7 +1922,7 @@ def test_sticky_range():
    5 frames hidden .*
 # sticky %d %d
 <CLEARSCREEN>
->.*
+[NUM] > .*fn(), 5 frames hidden
 
 %d \\s+         set_trace()
 NUM  ->         a = 1
@@ -1945,10 +1943,7 @@ def test_sticky_by_default():
         return a
 
     check(fn, """
-[NUM] > .*fn()
--> a = 1
-   5 frames hidden .*
-.*
+[NUM] > .*fn(), 5 frames hidden
 
 NUM         def fn():
 NUM             set_trace(Config=MyConfig)
@@ -1957,11 +1952,8 @@ NUM             b = 2
 NUM             c = 3
 NUM             return a
 # n
-[NUM] > .*fn()
--> b = 2
-   5 frames hidden .*
 <CLEARSCREEN>
->.*
+[NUM] > .*fn(), 5 frames hidden
 
 NUM         def fn():
 NUM             set_trace(Config=MyConfig)
@@ -1984,10 +1976,7 @@ def test_sticky_by_default_with_use_pygments_auto():
         return a
 
     check(fn, """
-[NUM] > .*fn()
--> a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
-   5 frames hidden .*
-.*
+[NUM] > .*fn(), 5 frames hidden
 
 NUM         ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
 NUM             set_trace(Config^[[38;5;241m=^[[39mMyConfig)
@@ -2018,7 +2007,7 @@ def test_sticky_dunder_exception():
    5 frames hidden .*
 # sticky
 <CLEARSCREEN>
-> {filename}(NUM)
+[NUM] > {filename}(NUM)fn(), 5 frames hidden
 
 NUM         def fn():
 NUM             def raises():
@@ -2054,7 +2043,7 @@ def test_sticky_dunder_exception_with_highlight():
    5 frames hidden .*
 # sticky
 <CLEARSCREEN>
-> {filename}(NUM)
+[NUM] > <COLORFNAME>{filename}<COLORRESET>(<COLORNUM>)fn(), 5 frames hidden
 
 <COLORNUM>         def fn():
 <COLORNUM>             def raises():
@@ -2109,6 +2098,10 @@ def test_sticky_dunder_return():
         set_trace()
         returns()
 
+    if sys.version_info < (3,):
+        py27_return = "--Return--\n"
+    else:
+        py27_return = ""
     check(fn, """
 [NUM] > .*fn()
 -> returns()
@@ -2120,19 +2113,15 @@ def test_sticky_dunder_return():
    5 frames hidden .*
 # sticky
 <CLEARSCREEN>
->.*
+[NUM] > .*(NUM)returns(), 5 frames hidden
 
 NUM  ->         def returns():
 NUM                 return 40 \\+ 2
 # retval
 \\*\\*\\* Not yet returned!
 # r
---Return--
-[NUM] > .*(NUM)returns()->42
--> return 40 \\+ 2
-   5 frames hidden .*
 <CLEARSCREEN>
-> {filename}(NUM)
+""" + py27_return + """[NUM] > {filename}(NUM)returns()->42, 5 frames hidden
 
 NUM             def returns():
 NUM  ->             return 40 \\+ 2
@@ -2145,7 +2134,7 @@ NUM  ->             return 40 \\+ 2
     ))
 
 
-def test_sticky_with_user_exception_does_not_clear_screen():
+def test_sticky_with_user_exception():
     def fn():
         def throws():
             raise InnerTestException()
@@ -2164,24 +2153,24 @@ def test_sticky_with_user_exception_does_not_clear_screen():
    5 frames hidden .*
 # sticky
 <CLEARSCREEN>
->.*
+[NUM] > .*throws(), 5 frames hidden
 
 NUM  ->         def throws():
 NUM                 raise InnerTestException()
 # n
-[NUM] > .*throws()
--> raise InnerTestException()
-   5 frames hidden .*
 <CLEARSCREEN>
->.*
+[NUM] > .*throws(), 5 frames hidden
 
 NUM             def throws():
 NUM  ->             raise InnerTestException()
 # n
-.*InnerTestException
-[NUM] > .*throws()
--> raise InnerTestException()
-   5 frames hidden .*
+<CLEARSCREEN>
+.*.InnerTestException
+[NUM] > .*throws(), 5 frames hidden
+
+NUM             def throws():
+NUM  ->             raise InnerTestException()
+InnerTestException:
 # c
 """)
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2142,6 +2142,10 @@ def test_sticky_with_user_exception():
         set_trace()
         throws()
 
+    if sys.version_info < (3,):
+        py27_exc = "InnerTestException: InnerTestException()\n"
+    else:
+        py27_exc = ""
     check(fn, """
 [NUM] > .*fn()
 -> throws()
@@ -2165,8 +2169,7 @@ NUM             def throws():
 NUM  ->             raise InnerTestException()
 # n
 <CLEARSCREEN>
-.*.InnerTestException
-[NUM] > .*throws(), 5 frames hidden
+""" + py27_exc + """[NUM] > .*throws(), 5 frames hidden
 
 NUM             def throws():
 NUM  ->             raise InnerTestException()


### PR DESCRIPTION
- clear screen in postcmd, which makes any output show up at the top.
  While it becomes "bumpy" then, this is less fragile than capturing
  stdout/stderr.  Fixes https://github.com/pdbpp/pdbpp/issues/122.

- only display as many lines as fit on the screen.
  Fixes https://github.com/pdbpp/pdbpp/issues/221.

- use lru_cache with format_source