### PR TITLE
Fix cutoff with max_lines, display all with `ll`

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1228,17 +1228,16 @@ except for when using the function decorator.
             self.curframe.f_lineno,
             exc_lineno if exc_lineno else 0) - lineno
 
-        cut_before = max(
-            min(
-                min(last_marker_line - 3, int(round(last_marker_line / 3 * 2))), cutoff,
-            ),
-            0,
+        # Place marker / current line in first third of available lines.
+        cut_before = min(
+            cutoff, max(0, last_marker_line - max_lines + max_lines // 3 * 2)
         )
         cut_after = cutoff - cut_before
 
         # Adjust for '...' lines.
         cut_after = cut_after + 1 if cut_after > 0 else 0
         if cut_before:
+            # Adjust for '...' line.
             cut_before += 1
 
         for i, line in enumerate(lines[keep_head:], keep_head):

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1201,9 +1201,12 @@ except for when using the function decorator.
         cutoff = len(lines) - max_lines
 
         # Keep certain top lines.
+        # Keeps decorators, but not functions, which are displayed at the top
+        # already (stack information).
+        # TODO: check behavior with lambdas.
         COLOR_OR_SPACE = r'(?:\x1b.*?m|\s)'
         keep_pat = re.compile(
-            r'(?:^{col}*(?:def{col}|async{col}+def{col}|@))'
+            r'(?:^{col}*@)'
             r'|(?<!\w)lambda(?::|{col})'.format(col=COLOR_OR_SPACE)
         )
         keep_head = 0

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1118,7 +1118,7 @@ except for when using the function decorator.
         installed, the source code is colorized.
         """
         self.lastcmd = 'longlist'
-        self._printlonglist()
+        self._printlonglist(max_lines=False)
 
     do_ll = do_longlist
 
@@ -1207,25 +1207,19 @@ except for when using the function decorator.
             lines = [self._truncate_to_visible_length(line, maxlength)
                      for line in lines]
 
+        lineno_width = len(str(lineno + len(lines)))
         if print_markers:
             exc_lineno = self.tb_lineno.get(self.curframe, None)
-            if height >= 6:
+            if max_lines is not False:
                 last_marker_line = max(
                     self.curframe.f_lineno,
                     exc_lineno if exc_lineno else 0) - lineno
-                if last_marker_line >= 0:
-                    maxlines = last_marker_line + height * 2 // 3
-                    if len(lines) > maxlines:
-                        lines = lines[:maxlines]
-                        lines.append('...')
+                if last_marker_line >= 0 and len(lines) > max_lines:
+                    maxlines = last_marker_line + max_lines
+                    lines = lines[last_marker_line:maxlines - 1]
+                    lines.append('...')
+                    lineno += last_marker_line
 
-        if max_lines and len(lines) > max_lines:
-            cutoff = max_lines - len(lines)
-            lines = lines[0 - max_lines:]
-            lineno -= cutoff
-
-        lineno_width = len(str(lineno + len(lines)))
-        if print_markers:
             set_bg = self.config.highlight and self.config.current_line_color
             for i, line in enumerate(lines):
                 if lineno == self.curframe.f_lineno:

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1193,10 +1193,7 @@ except for when using the function decorator.
         return ret
 
     def _cut_lines(self, lines, lineno, max_lines):
-        if not max_lines:
-            max_lines = len(lines)
-        elif max_lines < 6:
-            max_lines = 6
+        max_lines = max(6, len(lines) if not max_lines else max_lines)
         if len(lines) <= max_lines:
             for i, line in enumerate(lines, lineno):
                 yield i, line

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1204,7 +1204,7 @@ except for when using the function decorator.
         # Keeps decorators, but not functions, which are displayed at the top
         # already (stack information).
         # TODO: check behavior with lambdas.
-        COLOR_OR_SPACE = r'(?:\x1b.*?m|\s)'
+        COLOR_OR_SPACE = r'(?:\x1b[^m]+m|\s)'
         keep_pat = re.compile(
             r'(?:^{col}*@)'
             r'|(?<!\w)lambda(?::|{col})'.format(col=COLOR_OR_SPACE)

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -54,7 +54,7 @@ except ImportError:
 # effects free.
 side_effects_free = re.compile(r'^ *[_0-9a-zA-Z\[\].]* *$')
 
-RE_COLOR_ESCAPES = re.compile("(\x1b.*?m)+")
+RE_COLOR_ESCAPES = re.compile("(\x1b[^m]+m)+")
 RE_REMOVE_FANCYCOMPLETER_ESCAPE_SEQS = re.compile(r"\x1b\[[\d;]+m")
 
 if sys.version_info < (3, ):

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1193,7 +1193,11 @@ except for when using the function decorator.
         return ret
 
     def _cut_lines(self, lines, lineno, max_lines):
-        if not max_lines or len(lines) <= max_lines:
+        if not max_lines:
+            max_lines = len(lines)
+        elif max_lines < 6:
+            max_lines = 6
+        if len(lines) <= max_lines:
             for i, line in enumerate(lines, lineno):
                 yield i, line
             return
@@ -1221,7 +1225,6 @@ except for when using the function decorator.
         else:
             for i, line in enumerate(lines[:keep_head]):
                 yield lineno + i, line
-            # cutoff -= keep_head
 
         exc_lineno = self.tb_lineno.get(self.curframe, None)
         last_marker_line = max(

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2613,11 +2613,11 @@ def test_sticky_cutoff_with_decorator_colored():
 <COLORNUM>         ^[[38;5;129m@deco^[[39m
 ...
 <COLORNUM>             set_trace.*
-<COLORCURLINE>  ->         ^[[38;5;28;44mprint^[[39;44m(^[[38;5;241;44m1^[[39;44m) +^[[00m
+<COLORCURLINE>  ->         ^[[38;5;28.*;44mprint.*
 <COLORNUM>             ^[[38;5;28;01mreturn^[[39;00m
 # c
 1
-""", terminal_size=(80, 10))  # noqa: E501
+""", terminal_size=(80, 10))
 
 
 def test_sticky_cutoff_with_minimal_lines():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2513,7 +2513,7 @@ NUM             # 4
 ...
 # c
 1
-""", terminal_size=(80, 15))
+""", terminal_size=(200, 15))
 
 
 def test_sticky_cutoff_with_decorator():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2423,8 +2423,8 @@ def test_sticky_cutoff_with_head():
     check(fn, """
 [NUM] > .*fn(), 5 frames hidden
 
-NUM         def fn():
 ...
+NUM             # 4
 NUM             # 5
 NUM             set_trace(Config=MyConfig)
 NUM  ->         print(1)
@@ -2452,8 +2452,8 @@ def test_sticky_cutoff_with_head_and_tail():
     check(fn, """
 [NUM] > .*fn(), 5 frames hidden
 
-NUM         def fn():
 ...
+NUM             # 3
 NUM             set_trace(Config=MyConfig)
 NUM  ->         print(1)
 NUM             # 1
@@ -2500,8 +2500,8 @@ def test_sticky_cutoff_with_long_head_and_tail():
     check(fn, """
 [NUM] > .*fn(), 5 frames hidden
 
-NUM         def fn():
 ...
+NUM             # 9
 NUM             # 10
 NUM             set_trace(Config=MyConfig)
 NUM  ->         print(1)
@@ -2538,8 +2538,8 @@ def test_sticky_cutoff_with_decorator():
 [NUM] > .*fn(), 5 frames hidden
 
 NUM         @deco
-NUM         def fn():
 ...
+NUM             # 5
 NUM             set_trace(Config=MyConfig)
 NUM  ->         print(1)
 NUM             return
@@ -2578,7 +2578,7 @@ def test_sticky_cutoff_with_many_decorators():
 
 NUM         @deco
 ...
-NUM         def fn():
+NUM         @deco
 ...
 NUM  ->         print(1)
 NUM             return
@@ -2611,13 +2611,13 @@ def test_sticky_cutoff_with_decorator_colored():
 
 <COLORNUM>         ^[[38;5;129m@deco^[[39m
 <COLORNUM>         ^[[38;5;129m@deco^[[39m
-<COLORNUM>         ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
 ...
-<COLORCURLINE>  ->         ^[[38;5;28;44mprint^[[39;44m(^[[38;5;241;44m1^[[39;44m)                                                       ^[[00m
+<COLORNUM>             set_trace.*
+<COLORCURLINE>  ->         ^[[38;5;28;44mprint^[[39;44m(^[[38;5;241;44m1^[[39;44m) +^[[00m
 <COLORNUM>             ^[[38;5;28;01mreturn^[[39;00m
 # c
 1
-""", terminal_size=(80, 10))
+""", terminal_size=(80, 10))  # noqa: E501
 
 
 def test_exception_lineno():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1840,7 +1840,7 @@ NUM             a = 1
 NUM             return a
 # c
 
-""", terminal_size=(80, 10))
+""", terminal_size=(len(__file__) + 50, 10))
 
 
 class TestListWithChangedSource:
@@ -2403,7 +2403,7 @@ NUM             # 2
 ...
 # c
 1
-""", terminal_size=(80, 10))
+""", terminal_size=(len(__file__) + 50, 10))
 
 
 def test_sticky_cutoff_with_head():
@@ -2431,7 +2431,7 @@ NUM  ->         print(1)
 NUM             return
 # c
 1
-""", terminal_size=(80, 10))
+""", terminal_size=(len(__file__) + 50, 10))
 
 
 def test_sticky_cutoff_with_head_and_tail():
@@ -2460,7 +2460,7 @@ NUM             # 2
 ...
 # c
 1
-""", terminal_size=(80, 10))
+""", terminal_size=(len(__file__) + 50, 10))
 
 
 def test_sticky_cutoff_with_long_head_and_tail():
@@ -2513,7 +2513,7 @@ NUM             # 4
 ...
 # c
 1
-""", terminal_size=(200, 15))
+""", terminal_size=(len(__file__) + 50, 15))
 
 
 def test_sticky_cutoff_with_decorator():
@@ -2545,7 +2545,7 @@ NUM  ->         print(1)
 NUM             return
 # c
 1
-""", terminal_size=(80, 10))
+""", terminal_size=(len(__file__) + 50, 10))
 
 
 def test_sticky_cutoff_with_many_decorators():
@@ -2584,7 +2584,7 @@ NUM  ->         print(1)
 NUM             return
 # c
 1
-""", terminal_size=(80, 10))
+""", terminal_size=(len(__file__) + 50, 10))
 
 
 def test_sticky_cutoff_with_decorator_colored():
@@ -2617,7 +2617,7 @@ def test_sticky_cutoff_with_decorator_colored():
 <COLORNUM>             ^[[38;5;28;01mreturn^[[39;00m
 # c
 1
-""", terminal_size=(80, 10))
+""", terminal_size=(len(__file__) + 50, 10))
 
 
 def test_sticky_cutoff_with_minimal_lines():
@@ -2647,7 +2647,7 @@ NUM             # 2
 ...
 # c
 1
-""", terminal_size=(80, 3))
+""", terminal_size=(len(__file__) + 50, 3))
 
 
 def test_exception_lineno():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2453,10 +2453,10 @@ def test_sticky_cutoff_with_head_and_tail():
 [NUM] > .*fn(), 5 frames hidden
 
 ...
-NUM             # 3
 NUM             set_trace(Config=MyConfig)
 NUM  ->         print(1)
 NUM             # 1
+NUM             # 2
 ...
 # c
 1
@@ -2501,6 +2501,7 @@ def test_sticky_cutoff_with_long_head_and_tail():
 [NUM] > .*fn(), 5 frames hidden
 
 ...
+NUM             # 8
 NUM             # 9
 NUM             # 10
 NUM             set_trace(Config=MyConfig)
@@ -2509,7 +2510,6 @@ NUM             # 1
 NUM             # 2
 NUM             # 3
 NUM             # 4
-NUM             # 5
 ...
 # c
 1

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2620,6 +2620,36 @@ def test_sticky_cutoff_with_decorator_colored():
 """, terminal_size=(80, 10))  # noqa: E501
 
 
+def test_sticky_cutoff_with_minimal_lines():
+    class MyConfig(ConfigTest):
+        sticky_by_default = True
+
+    def deco(f):
+        return f
+
+    @deco
+    def fn():
+        set_trace(Config=MyConfig)
+        print(1)
+        # 1
+        # 2
+        # 3
+        return
+
+    check(fn, """
+[NUM] > .*fn(), 5 frames hidden
+
+NUM         @deco
+...
+NUM  ->         print(1)
+NUM             # 1
+NUM             # 2
+...
+# c
+1
+""", terminal_size=(80, 3))
+
+
 def test_exception_lineno():
     def bar():
         assert False


### PR DESCRIPTION
The current line not being displayed necessarily has regressed in c58b798.

`longlist` is documented to display the whole function.