### PR TITLE
stop_here: skip super() with Pdb=None

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1925,7 +1925,8 @@ except for when using the function decorator.
                 if not self._stopped_for_set_trace:
                     self._stopped_for_set_trace = True
                     return True
-        return super(Pdb, self).stop_here(frame)
+        if Pdb is not None:
+            return super(Pdb, self).stop_here(frame)
 
     def set_trace(self, frame=None):
         """Remember starting frame.


### PR DESCRIPTION
This might happen during shutdown (via logging), and some active
breakpoint:

    Exception ignored in: <function _removeHandlerRef at 0x7f4b8fbbf790>
    Traceback (most recent call last):
      File "/usr/lib/python3.8/logging/__init__.py", line 822, in _removeHandlerRef
      File "/usr/lib/python3.8/bdb.py", line 90, in trace_dispatch
      File "/usr/lib/python3.8/bdb.py", line 128, in dispatch_call
      File "…/lib/python3.8/site-packages/pdbpp.py",
          line 1990, in stop_here
    TypeError: super() argument 1 must be type, not None