### PR TITLE
Do not display `None` for no exception in interaction with traceback

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -455,7 +455,9 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
         # Handle post mortem via main: add exception similar to user_exception.
         if frame is None and traceback:
-            self.curframe.f_locals['__exception__'] = sys.exc_info()[:2]
+            exc = sys.exc_info()[:2]
+            if exc != (None, None):
+                self.curframe.f_locals['__exception__'] = exc
 
         if not self.sticky:
             self.print_stack_entry(self.stack[self.curindex])

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -5805,3 +5805,33 @@ def test_exception_info_main(testdir):
             "ValueError: foo",
         ]
     )
+
+
+def test_interaction_no_exception():
+    """Check that it does not display `None`."""
+    def outer():
+        try:
+            raise ValueError()
+        except ValueError:
+            return sys.exc_info()[2]
+
+    def fn():
+        tb = outer()
+        pdb_ = PdbTest()
+        pdb_.reset()
+        pdb_.interaction(None, tb)
+
+    check(fn, """
+[NUM] > .*outer()
+-> raise ValueError()
+# sticky
+<CLEARSCREEN>
+[0] > .*outer()
+
+NUM         def outer():
+NUM             try:
+NUM  >>             raise ValueError()
+NUM             except ValueError:
+NUM  ->             return sys.exc_info()[2]
+# q
+""")


### PR DESCRIPTION
Follow-up to be21980.