### PR TITLE
Stepping through only local code

### DIFF
--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -3955,6 +3955,7 @@ def test_stdout_encoding_None():
         instance.stdout = cStringIO.StringIO()
         instance.ensure_file_can_write_unicode(instance.stdout)
 
+
 def test_just_my_code():
     class ConfigJustMyCode(ConfigTest):
         just_my_code = True
@@ -3974,6 +3975,7 @@ def test_just_my_code():
    5 frames hidden .*
 # c
 """)
+
 
 def test_frame_cmd_changes_locals():
     def a():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -13,6 +13,7 @@ import textwrap
 import traceback
 from io import BytesIO
 
+import six
 import py
 import pytest
 
@@ -3954,6 +3955,25 @@ def test_stdout_encoding_None():
         instance.stdout = cStringIO.StringIO()
         instance.ensure_file_can_write_unicode(instance.stdout)
 
+def test_just_my_code():
+    class ConfigJustMyCode(ConfigTest):
+        just_my_code = True
+
+    def fn():
+        set_trace(Config=ConfigJustMyCode)
+        list(six.iterkeys({'foo': 'bar'}))
+
+    check(fn, """
+[NUM] > .*fn()
+-> list(six.iterkeys({'foo': 'bar'}))
+   5 frames hidden .*
+# s
+--Return--
+[NUM] > .*fn()
+-> list(six.iterkeys({'foo': 'bar'}))
+   5 frames hidden .*
+# c
+""")
 
 def test_frame_cmd_changes_locals():
     def a():


### PR DESCRIPTION
This pull request relates to the enhancement proposal: [403](https://github.com/pdbpp/pdbpp/issues/403)

In the unittest I used an example from six since that is already in src, avoiding importing anything else. Without just_my_code = True in the config, the code would instead step in to the [iterkeys function](https://github.com/benjaminp/six/blob/master/six.py#L582) of six.

In the src I had to add a test for os.path which seemed to be None in some cases (line 2056 below).
filepath = **os.path** and os.path.abspath(frame.f_code.co_filename)