### PR TITLE
Remove unused variable

### DIFF
--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1804,7 +1804,7 @@ NUM \t    \"""Ensure that forget was called for lineno.\"""
 NUM \t-> return a
 NUM \t   5 frames hidden .*
 # c
-""".format(line_num=fn.__code__.co_firstlineno))
+""")
 
 
 def test_shortlist_heuristic():


### PR DESCRIPTION
There is no `line_num` in the string for format to substitute. This is causing flake8 to complain during the build process. Removing the format call fixes it. This fixes https://github.com/pdbpp/pdbpp/issues/413