### PR TITLE
Fix _patch_linecache_for_source_highlight

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1382,12 +1382,7 @@ except for when using the function decorator.
 
         def wrapped_getlines(filename, globals):
             """Wrap linecache.getlines to highlight source (for do_list)."""
-            old_cache = pdb.linecache.cache.pop(filename, None)
-            try:
-                lines = orig(filename, globals)
-            finally:
-                if old_cache:
-                    pdb.linecache.cache[filename] = old_cache
+            lines = orig(filename, globals)
             source = self.format_source("".join(lines))
 
             if sys.version_info < (3,):


### PR DESCRIPTION
Do not pop the original cache.  This was meant to make sure that the
cache does not get messed with (based on the highlighted lines), but
breaks e.g. attrs' use of using the linecache for its generated code.