### PR TITLE
Fix `debug` with no previous tracing (e.g. in post mortem)

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1498,7 +1498,7 @@ except for when using the function decorator.
 
         prev_pdb = local.GLOBAL_PDB
         p = PdbppWithConfig(self.completekey, self.stdin, self.stdout)
-        p.prompt = "(%s) " % self.prompt.strip()
+        p._prompt = "({}) ".format(self._prompt.strip())
         self.message("ENTERING RECURSIVE DEBUGGER")
         try:
             with self._custom_completer():

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1473,12 +1473,16 @@ except for when using the function decorator.
     do_pp.__doc__ = pdb.Pdb.do_pp.__doc__
 
     def do_debug(self, arg):
-        # this is a hack (as usual :-))
-        #
-        # inside the original do_debug, there is a call to the global "Pdb" to
-        # instantiate the recursive debugger: we want to intercept this call
-        # and instantiate *our* Pdb, passing our custom config. Therefore we
-        # dynamically rebind the globals.
+        """debug code
+        Enter a recursive debugger that steps through the code
+        argument (which is an arbitrary expression or statement to be
+        executed in the current environment).
+        """
+        orig_trace = sys.gettrace()
+        if orig_trace:
+            sys.settrace(None)
+        globals = self.curframe.f_globals
+        locals = self.curframe_locals
         Config = self.ConfigFactory
 
         class PdbppWithConfig(self.__class__):
@@ -1492,27 +1496,23 @@ except for when using the function decorator.
                 local.GLOBAL_PDB = self_withcfg
                 local.GLOBAL_PDB._use_global_pdb_for_class = self.__class__
 
-        if sys.version_info < (3, ):
-            do_debug_func = pdb.Pdb.do_debug.im_func
-        else:
-            do_debug_func = pdb.Pdb.do_debug
-
-        newglobals = do_debug_func.__globals__.copy()
-        newglobals['Pdb'] = PdbppWithConfig
-        new_do_debug = rebind_globals(do_debug_func, newglobals)
-
-        # Handle any exception, e.g. SyntaxErrors.
-        # This is about to be improved in Python itself (3.8, 3.7.3?).
         prev_pdb = local.GLOBAL_PDB
+        p = PdbppWithConfig(self.completekey, self.stdin, self.stdout)
+        p.prompt = "(%s) " % self.prompt.strip()
+        self.message("ENTERING RECURSIVE DEBUGGER")
         try:
             with self._custom_completer():
-                return new_do_debug(self, arg)
+                sys.call_tracing(p.run, (arg, globals, locals))
         except Exception:
             exc_info = sys.exc_info()[:2]
-            msg = traceback.format_exception_only(*exc_info)[-1].strip()
-            self.error(msg)
+            self.error(traceback.format_exception_only(*exc_info)[-1].strip())
         finally:
             local.GLOBAL_PDB = prev_pdb
+        self.message("LEAVING RECURSIVE DEBUGGER")
+
+        if orig_trace:
+            sys.settrace(orig_trace)
+        self.lastcmd = p.lastcmd
 
     do_debug.__doc__ = pdb.Pdb.do_debug.__doc__
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -3805,14 +3805,6 @@ LEAVING RECURSIVE DEBUGGER
 
 
 def test_syntaxerror_in_command():
-    expected_debug_err = "ENTERING RECURSIVE DEBUGGER\n\\*\\*\\* SyntaxError: .*"
-
-    # Python 3.8.0a2+ handles the SyntaxError itself.
-    # Ref/followup: https://github.com/python/cpython/pull/12103
-    # https://github.com/python/cpython/commit/3e93643
-    if sys.version_info >= (3, 7, 3):
-        expected_debug_err += "\nLEAVING RECURSIVE DEBUGGER"
-
     def f():
         set_trace()
 
@@ -3824,9 +3816,11 @@ def test_syntaxerror_in_command():
 # print(
 \\*\\*\\* SyntaxError: .*
 # debug print(
-%s
+ENTERING RECURSIVE DEBUGGER
+\\*\\*\\* SyntaxError: .*
+LEAVING RECURSIVE DEBUGGER
 # c
-""" % expected_debug_err)
+""")
 
 
 def test_debug_with_overridden_continue():


### PR DESCRIPTION
This adopts `Pdb.do_debug`, given there are fixes in there already, and
it is not trivial to "patch out" the wrong `sys.settrace` in there
easily.

Ref: https://bugs.python.org/issue36388
Ref: https://github.com/python/cpython/pull/23202