### PR TITLE
Fix pdbpp.Pdb.hidden_frames discrepency with IPython.core.debugger.Pdb.hidden_frames

### DIFF
--- a/.ci/report-coverage.sh
+++ b/.ci/report-coverage.sh
@@ -3,8 +3,7 @@
 set -ex
 
 # Set --connect-timeout to work around https://github.com/curl/curl/issues/4461
-# NOTE: use version prior to https://github.com/codecov/codecov-bash/pull/373#issuecomment-727146528
-curl -S -L --connect-timeout 5 --retry 6 -s -o /tmp/codecov.sh https://raw.githubusercontent.com/codecov/codecov-bash/20201104-3e6f2fc/codecov
+curl -S -L --connect-timeout 5 --retry 6 -s -o /tmp/codecov.sh https://codecov.io/bash
 
 for _ in 1 2 3 4 5; do
   bash /tmp/codecov.sh -Z -X fix -X s3 -f coverage-ci.xml "$@" && break

--- a/.ci/report-coverage.sh
+++ b/.ci/report-coverage.sh
@@ -3,7 +3,8 @@
 set -ex
 
 # Set --connect-timeout to work around https://github.com/curl/curl/issues/4461
-curl -S -L --connect-timeout 5 --retry 6 -s -o /tmp/codecov.sh https://codecov.io/bash
+# NOTE: use version prior to https://github.com/codecov/codecov-bash/pull/373#issuecomment-727146528
+curl -S -L --connect-timeout 5 --retry 6 -s -o /tmp/codecov.sh https://raw.githubusercontent.com/codecov/codecov-bash/20201104-3e6f2fc/codecov
 
 for _ in 1 2 3 4 5; do
   bash /tmp/codecov.sh -Z -X fix -X s3 -f coverage-travis.xml "$@" && break

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
         - test $(python -c 'import sys; print("%d%d" % sys.version_info[0:2])') = 37
 
     - name: 'py39'
-      env: TOXENV=py39-coverage
+      env: TOXENV=py39-ipython-coverage
       python: 3.9
     - name: 'py38'
       env: TOXENV=py38-coverage

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -372,7 +372,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         self.tb_lineno = {}  # frame --> lineno where the exception raised
         self.history = []
         self.show_hidden_frames = False
-        self.hidden_frames = []
+        self.hidden_frame_list = []
 
         # Sticky mode.
         self.sticky = self.config.sticky_by_default
@@ -551,7 +551,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             self.fancycompleter.config.readline.set_completer(old_completer)
 
     def print_hidden_frames_count(self):
-        n = len(self.hidden_frames)
+        n = len(self.hidden_frame_list)
         if n and self.config.show_hidden_frames_count:
             plural = n > 1 and "s" or ""
             print(
@@ -621,16 +621,16 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         if self.show_hidden_frames:
             return fullstack, idx
 
-        self.hidden_frames = []
+        self.hidden_frame_list = []
         newstack = []
         for frame, lineno in fullstack:
             if self._is_hidden(frame):
-                self.hidden_frames.append((frame, lineno))
+                self.hidden_frame_list.append((frame, lineno))
             else:
                 newstack.append((frame, lineno))
         if not newstack:
-            newstack.append(self.hidden_frames.pop())
-        newidx = idx - len(self.hidden_frames)
+            newstack.append(self.hidden_frame_list.pop())
+        newidx = idx - len(self.hidden_frame_list)
         return newstack, newidx
 
     def refresh_stack(self):
@@ -1147,7 +1147,7 @@ except for when using the function decorator.
         self.refresh_stack()
 
     def do_hf_list(self, arg):
-        for frame_lineno in self.hidden_frames:
+        for frame_lineno in self.hidden_frame_list:
             print(self.format_stack_entry(frame_lineno, pdb.line_prefix),
                   file=self.stdout)
 
@@ -1613,7 +1613,7 @@ except for when using the function decorator.
                 self._sticky_messages = []
 
             if self.config.show_hidden_frames_count:
-                n = len(self.hidden_frames)
+                n = len(self.hidden_frame_list)
                 if n:
                     plural = n > 1 and "s" or ""
                     s += ", %d frame%s hidden" % (n, plural)

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -372,7 +372,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         self.tb_lineno = {}  # frame --> lineno where the exception raised
         self.history = []
         self.show_hidden_frames = False
-        self.hidden_frame_list = []
+        self._hidden_frames = []
 
         # Sticky mode.
         self.sticky = self.config.sticky_by_default
@@ -551,7 +551,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             self.fancycompleter.config.readline.set_completer(old_completer)
 
     def print_hidden_frames_count(self):
-        n = len(self.hidden_frame_list)
+        n = len(self._hidden_frames)
         if n and self.config.show_hidden_frames_count:
             plural = n > 1 and "s" or ""
             print(
@@ -621,16 +621,16 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         if self.show_hidden_frames:
             return fullstack, idx
 
-        self.hidden_frame_list = []
+        self._hidden_frames = []
         newstack = []
         for frame, lineno in fullstack:
             if self._is_hidden(frame):
-                self.hidden_frame_list.append((frame, lineno))
+                self._hidden_frames.append((frame, lineno))
             else:
                 newstack.append((frame, lineno))
         if not newstack:
-            newstack.append(self.hidden_frame_list.pop())
-        newidx = idx - len(self.hidden_frame_list)
+            newstack.append(self._hidden_frames.pop())
+        newidx = idx - len(self._hidden_frames)
         return newstack, newidx
 
     def refresh_stack(self):
@@ -1147,7 +1147,7 @@ except for when using the function decorator.
         self.refresh_stack()
 
     def do_hf_list(self, arg):
-        for frame_lineno in self.hidden_frame_list:
+        for frame_lineno in self._hidden_frames:
             print(self.format_stack_entry(frame_lineno, pdb.line_prefix),
                   file=self.stdout)
 
@@ -1613,7 +1613,7 @@ except for when using the function decorator.
                 self._sticky_messages = []
 
             if self.config.show_hidden_frames_count:
-                n = len(self.hidden_frame_list)
+                n = len(self._hidden_frames)
                 if n:
                     plural = n > 1 and "s" or ""
                     s += ", %d frame%s hidden" % (n, plural)

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 
 def test_integration(testdir, readline_param):
     tmpdir = testdir.tmpdir
@@ -60,3 +62,25 @@ def test_integration(testdir, readline_param):
         assert rest == b'\x1b[1@c\x1b[9D\r\n\r\x1b[?1l\x1b>'
     else:
         assert rest == b'c\r\n'
+
+
+def test_ipython(testdir):
+    """Test integration when used with IPython.
+
+    - `up` used to crash due to conflicting `hidden_frames` attribute/method.
+    """
+    pytest.importorskip("IPython")
+    child = testdir.spawn(
+        "{} -m IPython --colors=nocolor --simple-prompt".format(
+            sys.executable,
+        )
+    )
+    child.sendline("%debug raise ValueError('my_value_error')")
+    child.sendline("up")
+    child.expect_exact("\r\nipdb++> ")
+    child.sendline("c")
+    child.expect_exact("\r\nValueError: my_value_error\r\n")
+    child.expect_exact("\r\nIn [2]: ")
+    child.sendeof()
+    child.sendline("y")
+    assert child.wait() == 0

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py{27,34,35,36,37,38,39}, py{py,py3}
 extras = testing
 deps =
     coverage: pytest-cov
+    ipython: IPython
     pexpect
     # For tox's --force-dep to work (https://github.com/tox-dev/tox/issues/1199).
     pytest


### PR DESCRIPTION
Opening this PR primarily for discussion. As mentioned in #408, pdbpp doesn't work with IPython anymore, because `IPython.core.debugger.Pdb` has a [`hidden_frames`](https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.debugger.html#IPython.core.debugger.Pdb.hidden_frames) method that is at odds with the [`pdbpp.Pdb.hidden_frames`](https://github.com/pdbpp/pdbpp/blob/master/src/pdbpp.py#L375) attribute.

Just renaming the attribute in `pdbpp` fixes the problem but that's probably not a very good solution.

Any suggestions here? Thanks!