### PR TITLE
extend documentation for configuration file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,14 +1,6 @@
 CHANGELOG
 =========
 
-Unreleased
-==========
-
-- Misc:
-
-  - doc: extend description on how to use the configuration file
-
-
 Changes between 0.10.0 and 0.10.2
 =================================
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+Unreleased
+==========
+
+- Misc:
+
+  - doc: extend description on how to use the configuration file
+
+
 Changes between 0.10.0 and 0.10.2
 =================================
 

--- a/README.rst
+++ b/README.rst
@@ -389,7 +389,7 @@ Example configurations
 An example configuration file, which activates ``sticky mode`` by default,
 would look like the following::
 
-    import pdb
+    import pdbpp
 
     class Config(pdb.DefaultConfig):
         sticky_by_default = True
@@ -399,7 +399,7 @@ As seen in the sections above, you can also adjust the source code
 highlighting. In order to use true colors and the solarized-light theme, you
 have to create a configuration as follows::
 
-    import pdb
+    import pdbpp
 
     class Config(pdb.DefaultConfig):
         pygments_formatter_class = "pygments.formatters.TerminalTrueColorFormatter"

--- a/README.rst
+++ b/README.rst
@@ -238,6 +238,16 @@ Configuration and customization
 To customize pdb++, you can put a file named ``.pdbrc.py`` in your home
 directory.  The file must contain a class named ``Config`` inheriting from
 ``pdb.DefaultConfig`` and override the desired values.
+Do not forget to ``import pdb`` at the top of the configuration file.
+
+An example configuration file, which activates ``sticky mode`` by default,
+could would look like the following::
+
+    import pdb
+
+    class Config(pdb.DefaultConfig):
+        sticky_by_default = True
+
 
 The following is a list of the options you can customize, together with their
 default value:

--- a/README.rst
+++ b/README.rst
@@ -237,9 +237,8 @@ Configuration and customization
 
 To customize pdb++, you can put a file named ``.pdbrc.py`` in your home
 directory.  The file must contain a class named ``Config`` inheriting from
-``pdb.DefaultConfig`` and override the desired values.
-Do not forget to ``import pdb`` at the top of the configuration file.
-Also see `Example configurations`_.
+``pdbpp.DefaultConfig`` and override the desired values
+(see `Example configurations`_).
 
 The following is a list of the options you can customize, together with their
 default value:
@@ -391,7 +390,7 @@ would look like the following::
 
     import pdbpp
 
-    class Config(pdb.DefaultConfig):
+    class Config(pdbpp.DefaultConfig):
         sticky_by_default = True
 
 
@@ -401,7 +400,7 @@ have to create a configuration as follows::
 
     import pdbpp
 
-    class Config(pdb.DefaultConfig):
+    class Config(pdbpp.DefaultConfig):
         pygments_formatter_class = "pygments.formatters.TerminalTrueColorFormatter"
         pygments_formatter_kwargs = {"style": "solarized-light"}
 

--- a/README.rst
+++ b/README.rst
@@ -240,15 +240,6 @@ directory.  The file must contain a class named ``Config`` inheriting from
 ``pdb.DefaultConfig`` and override the desired values.
 Do not forget to ``import pdb`` at the top of the configuration file.
 
-An example configuration file, which activates ``sticky mode`` by default,
-would look like the following::
-
-    import pdb
-
-    class Config(pdb.DefaultConfig):
-        sticky_by_default = True
-
-
 The following is a list of the options you can customize, together with their
 default value:
 
@@ -374,14 +365,6 @@ Options relevant for source code highlighting (using Pygments)
      ``None`` (default: ``None`` = use builtin colorscheme).
      Only used by ``TerminalFormatter``.
 
-Example::
-
-    import pdb
-
-    class Config(pdb.DefaultConfig):
-        pygments_formatter_class = "pygments.formatters.TerminalTrueColorFormatter"
-        pygments_formatter_kwargs = {"style": "solarized-light"}
-
 .. _wmctrl: http://bitbucket.org/antocuni/wmctrl
 .. _SGR parameters: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
 
@@ -397,6 +380,30 @@ The following means "reset all colors" (``0``), set foreground color to 18
 
 Constants are available via ``pdb.Color``, e.g. ``pdb.Color.red``
 (``"31;01"``), but in general any string can be used here.
+
+
+Example configurations
+^^^^^^^^^^^^^^^^^^^^^^
+
+An example configuration file, which activates ``sticky mode`` by default,
+would look like the following::
+
+    import pdb
+
+    class Config(pdb.DefaultConfig):
+        sticky_by_default = True
+
+
+As seen in the sections above, you can also adjust the source code
+highlighting. In order to use true colors and the solarized-light theme, you
+have to create a configuration as follows::
+
+    import pdb
+
+    class Config(pdb.DefaultConfig):
+        pygments_formatter_class = "pygments.formatters.TerminalTrueColorFormatter"
+        pygments_formatter_kwargs = {"style": "solarized-light"}
+
 
 Coding guidelines
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -239,6 +239,7 @@ To customize pdb++, you can put a file named ``.pdbrc.py`` in your home
 directory.  The file must contain a class named ``Config`` inheriting from
 ``pdb.DefaultConfig`` and override the desired values.
 Do not forget to ``import pdb`` at the top of the configuration file.
+Also see `Example configurations`_.
 
 The following is a list of the options you can customize, together with their
 default value:

--- a/README.rst
+++ b/README.rst
@@ -376,6 +376,8 @@ Options relevant for source code highlighting (using Pygments)
 
 Example::
 
+    import pdb
+
     class Config(pdb.DefaultConfig):
         pygments_formatter_class = "pygments.formatters.TerminalTrueColorFormatter"
         pygments_formatter_kwargs = {"style": "solarized-light"}

--- a/README.rst
+++ b/README.rst
@@ -241,7 +241,7 @@ directory.  The file must contain a class named ``Config`` inheriting from
 Do not forget to ``import pdb`` at the top of the configuration file.
 
 An example configuration file, which activates ``sticky mode`` by default,
-could would look like the following::
+would look like the following::
 
     import pdb
 


### PR DESCRIPTION
Add note that you need to ``import pdb`` in order to make the
configuration file working.

When you miss the import, the configuration file will not be read and
also you do not see any error message.

Also, add an example configuration.