### PR TITLE
build(ci): codecov: remove verbose=true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,4 +147,3 @@ jobs:
         flags: ${{ runner.os }}
         name: ${{ matrix.tox_env }}
         fail_ci_if_error: true
-        verbose: true


### PR DESCRIPTION
Does it trigger `set -e` internally really?  (https://github.com/codecov/codecov-action/issues/182)