### PR TITLE
build(tox): drop not required explicit pytest dep

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,6 @@ deps =
     coverage: pytest-cov
     ipython: IPython
     pexpect
-    # For tox's --force-dep to work (https://github.com/tox-dev/tox/issues/1199).
-    pytest
 setenv =
     coverage: PYTEST_ADDOPTS=--cov "--cov-report=xml:{toxinidir}/coverage.xml" --cov-report=term-missing {env:PYTEST_ADDOPTS:}
 passenv =


### PR DESCRIPTION
This was meant to work around an issue with `tox --force-dep`, which was
likely a misunderstanding back then.

Fixes c08e511 (https://github.com/pdbpp/pdbpp/pull/333).