### PR TITLE
ensure !! escape is remembered for emptyline repeats

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -929,7 +929,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             # Force the "standard" behaviour, i.e. first check for the
             # command, then for the variable name to display.
             line = line[2:]
-            cmd, arg, newline =  super(Pdb, self).parseline(line)
+            cmd, arg, newline = super(Pdb, self).parseline(line)
             return cmd, arg, "!!" + newline
 
         if line.endswith('?') and not line.startswith("!"):

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -929,7 +929,8 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             # Force the "standard" behaviour, i.e. first check for the
             # command, then for the variable name to display.
             line = line[2:]
-            return super(Pdb, self).parseline(line)
+            cmd, arg, newline =  super(Pdb, self).parseline(line)
+            return cmd, arg, "!!" + newline
 
         if line.endswith('?') and not line.startswith("!"):
             arg = line.split('?', 1)[0]
@@ -947,7 +948,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
         # pdb++ "smart command mode": don't execute commands if a variable
         # with the name exists in the current context;
-        # This prevents pdb to quit if you type e.g. 'r[0]' by mystake.
+        # This prevents pdb to quit if you type e.g. 'r[0]' by mistake.
         cmd, arg, newline = super(Pdb, self).parseline(line)
 
         if cmd:

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1460,6 +1460,7 @@ True
 # cont
 """)
 
+
 def test_parseline_remembers_smart_command_escape():
     def fn():
         n = 42
@@ -1485,7 +1486,7 @@ def test_parseline_remembers_smart_command_escape():
 # n
 44
 # c
-""")
+""")  # noqa: W291
 
 
 def test_args_name():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1460,6 +1460,33 @@ True
 # cont
 """)
 
+def test_parseline_remembers_smart_command_escape():
+    def fn():
+        n = 42
+        set_trace()
+        n = 43
+        n = 44
+        return n
+
+    check(fn, """
+[NUM] > .*fn()
+-> n = 43
+   5 frames hidden .*
+# n
+42
+# !!n
+[NUM] > .*fn()
+-> n = 44
+   5 frames hidden .*
+# 
+[NUM] > .*fn()
+-> return n
+   5 frames hidden .*
+# n
+44
+# c
+""")
+
 
 def test_args_name():
     def fn():


### PR DESCRIPTION
This is to save the `!!` escape in` pdb.lastline`.  So that when a blank line is entered and the command is repeated, the escape is reused.