### PR TITLE
ci: GHA: use released Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         include:
           # Linux
           - tox_env: "py310-coverage"
-            python: "3.10.0-rc.2"
+            python: "3.10"
             os: ubuntu-20.04
           - tox_env: "py39-ipython-coverage"
             python: "3.9"

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -5031,6 +5031,11 @@ def test_chained_syntaxerror_with_traceback():
         set_trace()
 
     if sys.version_info > (3,):
+        if sys.version_info >= (3, 10, 0, "final"):  # changed after rc2 (bpo-45249).
+            caret_line = "           $"
+        else:
+            caret_line = "    .*^"
+
         check(fn, """
 --Return--
 [NUM] > .*fn()
@@ -5045,7 +5050,7 @@ Traceback (most recent call last):
     compile.*
   File "<stdin>", line 1
     invalid(
-    .*^
+""" + caret_line + """
 SyntaxError: .*
 
 During handling of the above exception, another exception occurred:


### PR DESCRIPTION
Test changed due to https://bugs.python.org/issue45249 - likely a regression in Python 3.10.0 (after 3.10.0rc2): reported at https://bugs.python.org/msg403588.