### PR TITLE
Fix (not) editing of an object implementing `str`

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1841,8 +1841,6 @@ except for when using the function decorator.
     def _get_position_of_obj(self, obj, quiet=False):
         if hasattr(inspect, "unwrap"):
             obj = inspect.unwrap(obj)
-        if isinstance(obj, str):
-            return obj, 1, None
         try:
             filename = inspect.getabsfile(obj)
             lines, lineno = inspect.getsourcelines(obj)

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -3124,6 +3124,28 @@ RUN emacs \+%d %s
 """ % (bar_lineno, RE_THIS_FILE_CANONICAL_QUOTED))
 
 
+def test_edit_str_obj():
+    class StrLike(str):
+        pass
+
+    def fn():
+        bar = StrLike()
+        set_trace()
+        return bar
+    _, edit_lineno = inspect.getsourcelines(StrLike)
+
+    check(fn, r"""
+[NUM] > .*fn()
+-> return bar
+   5 frames hidden .*
+# edit bar
+\*\*\* could not parse filename/lineno
+# edit StrLike
+RUN emacs \+{:d} {}
+# c
+""".format(edit_lineno, RE_THIS_FILE_CANONICAL_QUOTED))
+
+
 def test_edit_fname_lineno():
     def fn():
         set_trace()


### PR DESCRIPTION
With e.g. pip's tests there are `tests.lib.path.Path` instances derived
from `str`, where `edit cache_dir` would edit the path location, not the
one of the object.

This was added in https://github.com/pdbpp/pdbpp/commit/62010a4189b056f61c92d0e4d412f289a9e79cfe, without explanation nor test.  Do you remember something about it by chance, @antocuni? :)