### PR TITLE
Improve pdbpp.Pdb.parseline(): detect builtin with dot e.g list.foo

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -987,7 +987,13 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
                         and cmd + arg == line  # not for "debug ..." etc
                     ) or arg.startswith("="):
                         cmd, arg, newline = None, None, line
-                    elif arg.startswith("(") and cmd in ("list", "next"):
+                    elif (
+                        cmd in ("list", "next")
+                        and (
+                            arg.startswith("(")
+                            or arg.startswith('.')
+                        )
+                    ):
                         # heuristic: handle "list(...", "next(..." etc as builtin.
                         cmd, arg, newline = None, None, line
 


### PR DESCRIPTION
**Previous behavior:**
`pdbpp.Pdb.parseline()` correctly detects when the user calls a builtin like `list` and `next`, and does not mean to call the pdb `list` or `next` command, by checking whether `cmd in ("list", "next") and arg.startswith("(")`.

So this works as expected:
```python
(Pdb++) list([1])
[1]
```

**Problem:**
It doesn't detect cases when the user calls e.g `list.mro()` or `list.__getitem__([1], 0)`. 

So this doesn't work:
```python
(Pdb++) list.__getitem__([1], 0)
*** Error in argument: '.__getitem__([1], 0)'
```

**Fix:**
I've changed the condition to `cmd in ("list", "next") and (arg.startswith("(") or arg.startswith("."))` to fix that.

So now this works as expected:
```python
(Pdb++) list.__getitem__([1], 0)
1
```

Let me know if this makes sense, follows best practices etc. 

Thanks!
Gilad