### PR TITLE
docs: fix simple typo, differene -> difference

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -50,7 +50,7 @@ except ImportError:
         """Simple cache (with no maxsize basically) for py27 compatibility.
 
         Given that pdb there uses linecache.getline for each line with
-        do_list a cache makes a big differene."""
+        do_list a cache makes a big difference."""
 
         def dec(fn, *args):
             cache = {}


### PR DESCRIPTION
There is a small typo in src/pdbpp.py.

Should read `difference` rather than `differene`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md