### PR TITLE
fix python3.11 _ModuleTarget _ScriptTarget compatibility

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -132,11 +132,11 @@ def rebind_globals(func, newglobals):
         )
 
     # Python 3.11
-    _pdb = __import__("pdb", fromlist=("_ModuleTarget", "_ScriptTargetu"))
+    _pdb = __import__("pdb", fromlist=("_ModuleTarget", "_ScriptTarget"))
     if (
         hasattr(_pdb, '_ModuleTarget')
         and hasattr(_pdb, '_ScriptTarget')
-        and isinstance(func, (_pdb._ModuleTarget, _pdb._ScriptTarget))
+        and func.__name__ in ("_ModuleTarget", "_ScriptTarget")
     ):
         return func
 

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -131,6 +131,11 @@ def rebind_globals(func, newglobals):
             _newfunc(func.func, newglobals), *func.args, **func.keywords
         )
 
+    # Python 3.11
+    _pdb = __import__("pdb", fromlist=("_ModuleTarget", "_ScriptTarget"))
+    if isinstance(func, (_pdb._ModuleTarget, _pdb._ScriptTarget)):
+        return func
+
     raise ValueError("cannot handle func {!r}".format(func))
 
 
@@ -2199,7 +2204,16 @@ if hasattr(pdb, '_usage'):
     _usage = pdb._usage
 
 # copy some functions from pdb.py, but rebind the global dictionary
-for name in 'run runeval runctx runcall main set_trace'.split():
+for name in (
+    "run",
+    "runeval",
+    "runctx",
+    "runcall",
+    "main",
+    "set_trace",
+    "_ModuleTarget",  # Python 3.11
+    "_ScriptTarget",  # Python 3.11
+):
     func = getattr(pdb, name)
     globals()[name] = rebind_globals(func, globals())
 del name, func

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -132,8 +132,12 @@ def rebind_globals(func, newglobals):
         )
 
     # Python 3.11
-    _pdb = __import__("pdb", fromlist=("_ModuleTarget", "_ScriptTarget"))
-    if isinstance(func, (_pdb._ModuleTarget, _pdb._ScriptTarget)):
+    _pdb = __import__("pdb", fromlist=("_ModuleTarget", "_ScriptTargetu"))
+    if (
+        hasattr(_pdb, '_ModuleTarget')
+        and hasattr(_pdb, '_ScriptTarget')
+        and isinstance(func, (_pdb._ModuleTarget, _pdb._ScriptTarget))
+    ):
         return func
 
     raise ValueError("cannot handle func {!r}".format(func))


### PR DESCRIPTION
`python -m pdb myscript.py` currently does not work under Python 3.11

This fixes it, based on changes proposed by @blueyed in https://github.com/pdbpp/pdbpp/issues/516