### PR TITLE
Drop python <3.8, improve CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - "release-*"
   workflow_dispatch:
 
+  schedule:
+    - cron: "20 4 * * 2" # once a week
+
 env:
   PYTEST_ADDOPTS: "-vv --cov-report=xml:coverage-ci.xml"
   PIP_DISABLE_PIP_VERSION_CHECK: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,25 +31,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python: ["3.8"]
         tox_env: ["coverage"]
         include:
           - tox_env: "py38-ipython-coverage"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             python: "3.8"
           - tox_env: "py38-editable-coverage"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             python: "3.8"
           - tox_env: "py39-coverage"
-            os: ubuntu-20.04
+            os: ubuntu-latest
             python: "3.9"
           - tox_env: "py310-coverage"
             python: "3.10"
-            os: ubuntu-20.04
+            os: ubuntu-latest
           - tox_env: "py311-coverage"
             python: "3.11"
-            os: ubuntu-20.04
+            os: ubuntu-latest
+          - tox_env: "py312-coverage"
+            python: "3.12"
+            os: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
         python-version: ${{ matrix.python }}
       # Skip for py27, where it is available in the image (ubuntu-20.04).
       if: matrix.python != '2.7'
+    - name: Set up Python 2
+      if: matrix.python == '2.7'
+      run: |
+        ln -sfn/usr/bin/python2.7 /usr/bin/python
 
     # Caching.
     - name: set PY_CACHE_KEY
@@ -108,6 +112,7 @@ jobs:
 
     - name: (Initial) version information/pinning
       run: |
+        python -VV
         python -m site
         python -m pip --version
         python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
+      # Skip for py27, where it is available in the image (ubuntu-20.04).
+      if: matrix.python_version != '2.7'
 
     # Caching.
     - name: set PY_CACHE_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       if: matrix.python == '2.7'
       run: |
         ln -sfn /usr/bin/python2.7 /usr/local/bin/python
-        apt-get install python-pip
+        sudo apt-get install python-pip
 
     # Caching.
     - name: set PY_CACHE_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Set up Python 2
       if: matrix.python == '2.7'
       run: |
-        ln -sfn /usr/bin/python2.7 /usr/bin/python
+        ln -sfn /usr/bin/python2.7 /usr/local/bin/python
 
     # Caching.
     - name: set PY_CACHE_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       # Skip for py27, where it is available in the image (ubuntu-20.04).
       if: matrix.python != '2.7'
     - name: Set up Python 2
-      if: matrix.python == '2.7'
+      if: matrix.python == '2.7' && matrix.os != 'windows-2019'
       run: |
         ln -sfn /usr/bin/python2.7 /usr/local/bin/python
         curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       if: matrix.python == '2.7'
       run: |
         ln -sfn /usr/bin/python2.7 /usr/local/bin/python
+        python -m ensurepip
 
     # Caching.
     - name: set PY_CACHE_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
             os: windows-2019
             pytest: "pytest @ git+https://github.com/blueyed/pytest@my-4.6-maintenance"
             tox: tox==3.14.0  # tox 3.14.1 dropped support for py34.
-            tox_args: "-e py34-coverage"  # no '--durations'.
           - tox_env: "py27-coverage"
             python: "2.7"
             os: windows-2016
@@ -120,7 +119,7 @@ jobs:
         python -m pip install -U virtualenv==20.4.3
 
     - name: Install tox
-      run: python -m pip install ${{ matrix.tox || 'git+https://github.com/blueyed/tox@master' }}
+      run: python -m pip install ${{ matrix.tox || 'tox' }}
 
     - name: Version information
       run: python -m pip list
@@ -129,8 +128,7 @@ jobs:
       id: setup_tox
       env:
         PYTEST: ${{ matrix.pytest || 'pytest @ git+https://github.com/blueyed/pytest@my-master' }}
-        TOX_ARGS: "${{ matrix.tox_args || format('--durations -e {0}', matrix.tox_env) }}"
-      run: python -m tox --notest -v $TOX_ARGS --force-dep="$PYTEST"
+      run: python -m tox --notest -v -e {{ matrix.tox_env }} --force-dep="$PYTEST"
 
     - name: Test
       env:
@@ -139,9 +137,8 @@ jobs:
         PYTEST: ${{ matrix.pytest || 'pytest @ git+https://github.com/blueyed/pytest@my-master' }}
         # UTF-8 mode for Windows (https://docs.python.org/3/using/windows.html#utf-8-mode).
         PYTHONUTF8: "1"
-        TOX_ARGS: "${{ matrix.tox_args || format('--durations -e {0}', matrix.tox_env) }}"
         TOX_TESTENV_PASSENV: "PYTHONUTF8"
-      run: python -m tox -v $TOX_ARGS --force-dep="$PYTEST"
+      run: python -m tox -v -e {{ matrix.tox_env }} --force-dep="$PYTEST"
 
     - name: Report coverage
       if: always() && (contains(matrix.tox_env, '-coverage') && (steps.setup_tox.outcome == 'success'))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
       # Skip for py27, where it is available in the image (ubuntu-20.04).
-      if: matrix.python_version != '2.7'
+      if: matrix.python != '2.7'
 
     # Caching.
     - name: set PY_CACHE_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       if: matrix.python == '2.7'
       run: |
         ln -sfn /usr/bin/python2.7 /usr/local/bin/python
-        python -m ensurepip
+        apt-get install python-pip
 
     # Caching.
     - name: set PY_CACHE_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       id: setup_tox
       env:
         PYTEST: ${{ matrix.pytest || 'pytest @ git+https://github.com/blueyed/pytest@my-master' }}
-      run: python -m tox --notest -v -e {{ matrix.tox_env }} --force-dep="$PYTEST"
+      run: python -m tox --notest -v -e ${{ matrix.tox_env }} --force-dep="$PYTEST"
 
     - name: Test
       env:
@@ -138,7 +138,7 @@ jobs:
         # UTF-8 mode for Windows (https://docs.python.org/3/using/windows.html#utf-8-mode).
         PYTHONUTF8: "1"
         TOX_TESTENV_PASSENV: "PYTHONUTF8"
-      run: python -m tox -v -e {{ matrix.tox_env }} --force-dep="$PYTEST"
+      run: python -m tox -v -e ${{ matrix.tox_env }} --force-dep="$PYTEST"
 
     - name: Report coverage
       if: always() && (contains(matrix.tox_env, '-coverage') && (steps.setup_tox.outcome == 'success'))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
             tox: tox==3.14.0  # tox 3.14.1 dropped support for py34.
           - tox_env: "py27-coverage"
             python: "2.7"
-            os: windows-2016
+            os: windows-2019
             pytest: "pytest @ git+https://github.com/blueyed/pytest@my-4.6-maintenance"
 
           # Generic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           # macOS
           - tox_env: "py37-coverage"
             python: "3.7"
-            os: macos-10.15
+            os: macos-12
 
           # Windows
           - tox_env: "py38-coverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on:
   push:
@@ -21,139 +21,76 @@ defaults:
 
 jobs:
   tests:
+    name: Tests
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-20.04, windows-latest, macos-latest]
+        python: ["3.8"]
+        tox_env: ["coverage"]
         include:
-          # Linux
+          - tox_env: "py38-ipython-coverage"
+            os: ubuntu-20.04
+            python: "3.8"
+          - tox_env: "py38-editable-coverage"
+            os: ubuntu-20.04
+            python: "3.8"
+          - tox_env: "py39-coverage"
+            os: ubuntu-20.04
+            python: "3.9"
           - tox_env: "py310-coverage"
             python: "3.10"
             os: ubuntu-20.04
-          - tox_env: "py39-ipython-coverage"
-            python: "3.9"
-            os: ubuntu-20.04
-          - tox_env: "py38-editable-coverage"
-            python: "3.8"
-            os: ubuntu-20.04
-          - tox_env: "py37-coverage"
-            python: "3.7"
-            os: ubuntu-20.04
-          - tox_env: "py36-coverage"
-            python: "3.6"
-            os: ubuntu-20.04
-          - tox_env: "py35-coverage"
-            python: "3.5"
-            os: ubuntu-20.04
-
-          - tox_env: "py27-coverage"
-            python: "2.7"
-            os: ubuntu-20.04
-            pytest: "pytest @ git+https://github.com/blueyed/pytest@my-4.6-maintenance"
-
-          - tox_env: "pypy3-coverage"
-            python: "pypy-3.7"
-            os: ubuntu-20.04
-          - tox_env: "pypy-coverage"
-            python: "pypy-2.7"
-            os: ubuntu-20.04
-            pytest: "pytest @ git+https://github.com/blueyed/pytest@my-4.6-maintenance"
-
-          # macOS
           - tox_env: "py311-coverage"
             python: "3.11"
-            os: macos-11
-
-          # Windows
-          - tox_env: "py38-coverage"
-            python: "3.8"
-            os: windows-2019
-          - tox_env: "py34-coverage"
-            python: "3.4"
-            # Python 3.4 is only available on Windows.
-            # (https://github.com/actions/setup-python/issues/157#issuecomment-724152312)
-            os: windows-2019
-            pytest: "pytest @ git+https://github.com/blueyed/pytest@my-4.6-maintenance"
-            tox: tox==3.14.0  # tox 3.14.1 dropped support for py34.
-          - tox_env: "py27-coverage"
-            python: "2.7"
-            os: windows-2019
-            pytest: "pytest @ git+https://github.com/blueyed/pytest@my-4.6-maintenance"
-
-          # Generic
-          - tox_env: "checkqa"
-            python: "3.9"
             os: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 2000
-    - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-      # Skip for py27, where it is available in the image (ubuntu-20.04).
-      if: matrix.python != '2.7'
-    - name: Set up Python 2
-      if: matrix.python == '2.7' && matrix.os != 'windows-2019'
-      run: |
-        ln -sfn /usr/bin/python2.7 /usr/local/bin/python
-        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-        python get-pip.py
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
 
-    # Caching.
-    - name: set PY_CACHE_KEY
-      run: echo "PY_CACHE_KEY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
-    - name: Cache .tox
-      uses: actions/cache@v1
-      with:
-        path: ${{ github.workspace }}/.tox/${{ matrix.tox_env }}
-        key: "tox|${{ matrix.os }}|${{ matrix.tox_env }}|${{ env.PY_CACHE_KEY }}|${{ hashFiles('tox.ini', 'setup.*') }}"
+      - name: set PY_CACHE_KEY
+        run: echo "PY_CACHE_KEY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
+      - name: Cache .tox
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.tox/${{ matrix.tox_env }}
+          key: "tox|${{ matrix.os }}|${{ matrix.tox_env }}|${{ env.PY_CACHE_KEY }}|${{ hashFiles('tox.ini', 'setup.*') }}"
 
-    - name: (Initial) version information/pinning
-      run: |
-        python -VV
-        python -m site
-        python -m pip --version
-        python -m pip list
-        if [[ "${{ matrix.python }}" == "3.4" ]]; then
-          # Install latest available pip.
-          # 7.1.2 (installed) is too old to not install too new packages,
-          # including pip itself.  19.2 dropped support for Python 3.4.
-          python -m pip install -U pip==19.1.1
-        fi
-        python -m pip install -U setuptools==42.0.2
-        python -m pip install -U virtualenv==20.4.3
+      - name: Update tools and print info
+        run: |
+          pip install -U pip setuptools virtualenv
+          pip list
 
-    - name: Install tox
-      run: python -m pip install ${{ matrix.tox || 'tox' }}
+      - name: Install tox
+        run: pip install tox
 
-    - name: Version information
-      run: python -m pip list
+      - name: Setup tox environment
+        id: setup_tox
+        run: tox --notest -v -e ${{ matrix.tox_env }}
 
-    - name: Setup tox environment
-      id: setup_tox
-      env:
-        PYTEST: ${{ matrix.pytest || 'pytest @ git+https://github.com/blueyed/pytest@my-master' }}
-      run: python -m tox --notest -v -e ${{ matrix.tox_env }} --force-dep="$PYTEST"
+      - name: Test
+        env:
+          COLUMNS: "90" # better alignment (working around https://github.com/blueyed/pytest/issues/491).
+          PY_COLORS: "1"
+        run: |
+          if [[ ${{ matrix.os }} = "windows-latest" ]]; then
+            # UTF-8 mode for Windows (https://docs.python.org/3/using/windows.html#utf-8-mode).
+            export PYTHONUTF8=1 TOX_TESTENV_PASSENV=PYTHONUTF8
+          fi
+          python -m tox -v -e ${{ matrix.tox_env }}
 
-    - name: Test
-      env:
-        COLUMNS: "90"  # better alignment (working around https://github.com/blueyed/pytest/issues/491).
-        PY_COLORS: "1"
-        PYTEST: ${{ matrix.pytest || 'pytest @ git+https://github.com/blueyed/pytest@my-master' }}
-        # UTF-8 mode for Windows (https://docs.python.org/3/using/windows.html#utf-8-mode).
-        PYTHONUTF8: "1"
-        TOX_TESTENV_PASSENV: "PYTHONUTF8"
-      run: python -m tox -v -e ${{ matrix.tox_env }} --force-dep="$PYTEST"
-
-    - name: Report coverage
-      if: always() && (contains(matrix.tox_env, '-coverage') && (steps.setup_tox.outcome == 'success'))
-      uses: codecov/codecov-action@v3
-      with:
-        files: ./coverage-ci.xml
-        flags: ${{ runner.os }}
-        name: ${{ matrix.tox_env }}
-        fail_ci_if_error: true
+      - name: Report coverage
+        if: always() && (contains(matrix.tox_env, 'coverage') && (steps.setup_tox.outcome == 'success'))
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage-ci.xml
+          flags: ${{ runner.os }}
+          name: ${{ matrix.tox_env }}
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
             pytest: "pytest @ git+https://github.com/blueyed/pytest@my-4.6-maintenance"
 
           # macOS
-          - tox_env: "py37-coverage"
-            python: "3.7"
-            os: macos-12
+          - tox_env: "py311-coverage"
+            python: "3.11"
+            os: macos-11
 
           # Windows
           - tox_env: "py38-coverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       if: matrix.python == '2.7'
       run: |
         ln -sfn /usr/bin/python2.7 /usr/local/bin/python
-        sudo apt-get install python-pip
+        sudo apt-get install -y python-pip
 
     # Caching.
     - name: set PY_CACHE_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,8 @@ jobs:
       if: matrix.python == '2.7'
       run: |
         ln -sfn /usr/bin/python2.7 /usr/local/bin/python
-        sudo apt-get install -y python-pip
+        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+        python get-pip.py
 
     # Caching.
     - name: set PY_CACHE_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Set up Python 2
       if: matrix.python == '2.7'
       run: |
-        ln -sfn/usr/bin/python2.7 /usr/bin/python
+        ln -sfn /usr/bin/python2.7 /usr/bin/python
 
     # Caching.
     - name: set PY_CACHE_KEY

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ on:
       - "release-*"
   workflow_dispatch:
 
+  schedule:
+    - cron: "20 4 * * 2" # once a week
+
 jobs:
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ["3.8", "3.9", "3.10", "3.11"]
+        pyv: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,50 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - "master"
+      - "release-*"
+  pull_request:
+    branches:
+      - "master"
+      - "release-*"
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, windows-latest, macos-latest]
+        pyv: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.pyv }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.pyv }}
+
+      - name: set PY_CACHE_KEY
+        run: echo "PY_CACHE_KEY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
+      - name: Cache .tox
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.tox/checkqa
+          key: "tox-lint|${{ matrix.os }}|${{ env.PY_CACHE_KEY }}|${{ hashFiles('tox.ini', 'setup.*') }}"
+
+      - name: Update pip/setuptools
+        run: |
+          pip install -U pip setuptools
+
+      - name: Install tox
+        run: python -m pip install tox
+
+      - name: Version information
+        run: python -m pip list
+
+      - name: Lint
+        run: tox -v -e checkqa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+src/pdbpp_utils/_version.py
+
 # Ignore local virtualenvs
 syntax:glob
 lib/

--- a/README.rst
+++ b/README.rst
@@ -36,18 +36,7 @@ unexpected behavior, please report it as a bug.
 Installation
 ------------
 
-Since ``pdb++`` is not a valid package name the package is named ``pdbpp``::
-
-    $ pip install pdbpp
-
-``pdb++`` is also available via `conda`_::
-
-    $ conda install -c conda-forge pdbpp
-
-Alternatively, you can just put ``pdb.py`` somewhere inside your
-``PYTHONPATH``.
-
-.. _conda: https://anaconda.org/conda-forge/pdbpp
+    $ pip install https://github.com/bretello/pdbpp
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -281,11 +281,6 @@ default value:
 ``truncate_long_lines = True``
   Truncate lines which exceed the terminal width.
 
-``exec_if_unfocused = None``
-  Shell command to execute when starting the pdb prompt and the terminal
-  window is not focused.  Useful to e.g. play a sound to alert the user that
-  the execution of the program stopped. It requires the wmctrl_ module.
-
 ``enable_hidden_frames = True``
   Certain frames can be hidden by default.
   If enabled, the commands ``hf_unhide``, ``hf_hide``, and ``hf_list`` can be
@@ -370,7 +365,6 @@ Example::
         pygments_formatter_class = "pygments.formatters.TerminalTrueColorFormatter"
         pygments_formatter_kwargs = {"style": "solarized-light"}
 
-.. _wmctrl: http://bitbucket.org/antocuni/wmctrl
 .. _SGR parameters: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
 
 Notes on color options

--- a/README.rst
+++ b/README.rst
@@ -89,11 +89,6 @@ The following are new commands that you can use from the interactive
   names found in the current scope.
 
 
-``track EXPRESSION``
-  Display a graph showing which objects are the value of the expression refers
-  to and are referred by.  This command requires the ``pypy`` source code to
-  be importable.
-
 ``display EXPRESSION``
   Add an expression to the **display list**; expressions in this list are
   evaluated at each step, and printed every time its value changes.

--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ pdb++.
   by default, it breaks every time the attribute is set. E.g.::
 
       @break_on_setattr('bar')
-      class Foo(object):
+      class Foo:
           pass
       f = Foo()
       f.bar = 42    # the program breaks here
@@ -211,7 +211,7 @@ pdb++.
   If can be used even after the class has already been created, e.g. if we
   want to break when some attribute of a particular object is set::
 
-      class Foo(object):
+      class Foo:
           pass
       a = Foo()
       b = Foo()

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,4 @@ codecov:
   notify:
     after_n_builds: 12
     wait_for_ci: false
+  token: 4618b651-99b4-456c-b09e-f848a532b854

--- a/pdbpp_hijack_pdb.pth
+++ b/pdbpp_hijack_pdb.pth
@@ -7,5 +7,5 @@
 #    i.e. PDBPP_HIJACK_PDB=0 can be used to disable it.
 # 2. there is not another one already at the beginning
 #    (e.g. via a virtualenv using "include-system-site-packages")
-import os; _pdbpp_path = os.path.sep + "_pdbpp_path_hack"
+import os; _pdbpp_path = f"{os.path.sep}_pdbpp_path_hack"
 import sys; sys.path.insert(0, makepath(sitedir, "_pdbpp_path_hack")[0]) if int(os.environ.get('PDBPP_HIJACK_PDB', 1)) and not sys.path[0].endswith(_pdbpp_path) else None

--- a/pdbrc.py
+++ b/pdbrc.py
@@ -13,7 +13,6 @@ class Config(pdb.DefaultConfig):
     stdin_paste = 'epaste'
     filename_color = pdb.Color.lightgray
     use_terminal256formatter = False
-    # exec_if_unfocused = "play ~/sounds/dialtone.wav 2> /dev/null &"
 
     def __init__(self):
         # import readline

--- a/pdbrc.py
+++ b/pdbrc.py
@@ -1,40 +1,33 @@
 """
 This is an example configuration file for pdb++.
 
-Actually, it is what the author uses daily :-). Put it into ~/.pdbrc.py to use
-it.
+Put it into ~/.pdbrc.py to use it.
 """
 import pdb
 
+from pygments.styles import get_style_by_name
+
 
 class Config(pdb.DefaultConfig):
+    # prompt = "(Pdb++) "
+    sticky_by_default = True  # shows full code context at every step
 
-    editor = 'e'
-    stdin_paste = 'epaste'
-    filename_color = pdb.Color.lightgray
-    use_terminal256formatter = False
+    use_pygments = True
+    pygments_formatter_class = "pygments.formatters.TerminalTrueColorFormatter"
+    # get available style names with the snippet below
+    pygments_formatter_kwargs = {"style": get_style_by_name("gruvbox-dark")}
 
-    def __init__(self):
-        # import readline
-        # readline.parse_and_bind('set convert-meta on')
-        # readline.parse_and_bind('Meta-/: complete')
-
-        try:
-            from pygments.formatters import terminal
-        except ImportError:
-            pass
-        else:
-            self.colorscheme = terminal.TERMINAL_COLORS.copy()
-            self.colorscheme.update({
-                terminal.Keyword:            ('darkred',     'red'),
-                terminal.Number:             ('darkyellow',  'yellow'),
-                terminal.String:             ('brown',       'green'),
-                terminal.Name.Function:      ('darkgreen',   'blue'),
-                terminal.Name.Namespace:     ('teal',        'turquoise'),
-                })
+    editor = "vim"
 
     def setup(self, pdb):
         # make 'l' an alias to 'longlist'
         Pdb = pdb.__class__
         Pdb.do_l = Pdb.do_longlist
         Pdb.do_st = Pdb.do_sticky
+
+
+if __name__ == "__main__":
+    from pygments.styles import get_all_styles
+
+    all_styles = get_all_styles()
+    print(list(all_styles))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,7 @@ ignore = ["F401", "E722"]
 "src/pdbpp.py" = [
     "B019" # lru cache can lead to memory leaks. TODO: stop silencing the error and fix it
 ]
+
+[tool.pytest.ini_options]
+addopts = "-ra --tb short -p pytester"
+testpaths = ["testing"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ ignore = ["F401", "E722"]
 [tool.pytest.ini_options]
 addopts = "-ra --tb short -p pytester"
 testpaths = ["testing"]
+
+[tool.setuptools_scm]
+write_to = "src/pdbpp_utils/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ select = [
 ]
 ignore = ["F401", "E722"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "testing/**" = ["S", "B011", "B904"]
 "src/pdbpp.py" = [
     "B019" # lru cache can lead to memory leaks. TODO: stop silencing the error and fix it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ ignore = ["F401", "E722"]
 
 [tool.ruff.per-file-ignores]
 "testing/**" = ["S", "B011", "B904"]
+"src/pdbpp.py" = [
+    "B019" # lru cache can lead to memory leaks. TODO: stop silencing the error and fix it
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,4 @@ select = [
 ignore = ["F401", "E722"]
 
 [tool.ruff.per-file-ignores]
-"testing/**" = ["S", "B011"]
+"testing/**" = ["S", "B011", "B904"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+  # pycodestyle
+  "E",
+  # Pyflakes
+  "F",
+  # pyupgrade
+  "UP",
+  # flake8-bugbear
+  "B",
+  # flake8-simplify
+  "SIM",
+  # isort
+  "I",
+]
+ignore = ["F401", "E722"]
+
+[tool.ruff.per-file-ignores]
+"testing/**" = ["S", "B011"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[bdist_wheel]
-universal = 1
-
-[tool:pytest]
-testpaths = testing
-addopts = -ra --tb short -p pytester

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,6 @@
 [bdist_wheel]
 universal = 1
 
-[flake8]
-max-line-length = 88
-# E722: base excepts
-extend-ignore = E722
-
 [tool:pytest]
 testpaths = testing
 addopts = -ra --tb short -p pytester

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     ],
     install_requires=[
         "fancycompleter @ git+https://github.com/bretello/fancycompleter",  # noqa: E501
-        "wmctrl",
         "pygments",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "Topic :: Software Development :: Debuggers",
     ],
     install_requires=[
-        "fancycompleter @ git+https://github.com/bretello/fancycompleter@0.10.3",  # noqa: E501
+        "fancycompleter @ git+https://github.com/bretello/fancycompleter@0.10.4",  # noqa: E501
         "pygments",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "Topic :: Software Development :: Debuggers",
     ],
     install_requires=[
-        "fancycompleter @ git+https://github.com/pdbpp/fancycompleter@master#egg=fancycompleter",  # noqa: E501
+        "fancycompleter @ git+https://github.com/bretello/fancycompleter",  # noqa: E501
         "wmctrl",
         "pygments",
     ],

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     platforms=["unix", "linux", "osx", "cygwin", "win32"],
     description="pdb++, a drop-in replacement for pdb",
     long_description=long_description,
-    keywords="pdb debugger tab color completion",
+    keywords=["pdb", "debugger", "tab", "color", "completion"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     use_scm_version=True,
     author="Antonio Cuni",
     author_email="anto.cuni@gmail.com",
-    py_modules=["pdbpp", "_pdbpp_path_hack.pdb"],
     package_dir={"": "src"},
     url="https://github.com/pdbpp/pdbpp",
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "Topic :: Software Development :: Debuggers",
     ],
     install_requires=[
-        "fancycompleter @ git+https://github.com/bretello/fancycompleter",  # noqa: E501
+        "fancycompleter @ git+https://github.com/bretello/fancycompleter@0.10.3",  # noqa: E501
         "pygments",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,9 @@ setup(
         "fancycompleter @ git+https://github.com/pdbpp/fancycompleter@master#egg=fancycompleter",  # noqa: E501
         "wmctrl",
         "pygments",
-        "six",
     ],
     extras_require={
-        "funcsigs": ["funcsigs"],
         "testing": [
-            "funcsigs",
             "pytest",
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -1,56 +1,50 @@
-from __future__ import print_function
-from sysconfig import get_path
-
-import io
 import os.path
+from sysconfig import get_path
 
 from setuptools import setup
 
-readme_path = os.path.join(os.path.dirname(__file__), 'README.rst')
-changelog_path = os.path.join(os.path.dirname(__file__), 'CHANGELOG')
+readme_path = os.path.join(os.path.dirname(__file__), "README.rst")
+changelog_path = os.path.join(os.path.dirname(__file__), "CHANGELOG")
 
-readme = io.open(readme_path, encoding='utf-8').read()
-changelog = io.open(changelog_path, encoding='utf-8').read()
+with open(readme_path, encoding="utf-8") as fh:
+    readme = fh.read()
+with open(changelog_path, encoding="utf-8") as fh:
+    changelog = fh.read()
 
-long_description = readme + '\n\n' + changelog
+long_description = readme + "\n\n" + changelog
 
 setup(
-    name='pdbpp',
+    name="pdbpp",
     use_scm_version=True,
-    author='Antonio Cuni',
-    author_email='anto.cuni@gmail.com',
-    py_modules=['pdbpp', '_pdbpp_path_hack.pdb'],
+    author="Antonio Cuni",
+    author_email="anto.cuni@gmail.com",
+    py_modules=["pdbpp", "_pdbpp_path_hack.pdb"],
     package_dir={"": "src"},
-    url='https://github.com/pdbpp/pdbpp',
+    url="https://github.com/pdbpp/pdbpp",
     project_urls={
-        'Bug Tracker': 'https://github.com/pdbpp/pdbpp/issues',
-        'Source Code': 'https://github.com/pdbpp/pdbpp',
+        "Bug Tracker": "https://github.com/pdbpp/pdbpp/issues",
+        "Source Code": "https://github.com/pdbpp/pdbpp",
     },
-    license='BSD',
-    platforms=['unix', 'linux', 'osx', 'cygwin', 'win32'],
-    description='pdb++, a drop-in replacement for pdb',
+    license="BSD",
+    platforms=["unix", "linux", "osx", "cygwin", "win32"],
+    description="pdb++, a drop-in replacement for pdb",
     long_description=long_description,
-    keywords='pdb debugger tab color completion',
+    keywords="pdb debugger tab color completion",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: POSIX',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Programming Language :: Python',
-        'Topic :: Utilities',
-        'Topic :: Software Development :: Debuggers',
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: POSIX",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Programming Language :: Python",
+        "Topic :: Utilities",
+        "Topic :: Software Development :: Debuggers",
     ],
     install_requires=[
         "fancycompleter @ git+https://github.com/pdbpp/fancycompleter@master#egg=fancycompleter",  # noqa: E501
@@ -59,13 +53,13 @@ setup(
         "six",
     ],
     extras_require={
-        'funcsigs': ["funcsigs"],
-        'testing': [
-            'funcsigs',
-            'pytest',
+        "funcsigs": ["funcsigs"],
+        "testing": [
+            "funcsigs",
+            "pytest",
         ],
     },
-    setup_requires=['setuptools_scm'],
+    setup_requires=["setuptools_scm"],
     data_files=[
         (
             os.path.relpath(get_path("purelib"), get_path("data")),

--- a/src/_pdbpp_path_hack/pdb.py
+++ b/src/_pdbpp_path_hack/pdb.py
@@ -7,14 +7,14 @@ You can set PDBPP_HIJACK_PDB=0 as an environment variable to skip it.
 import os
 import sys
 
-pdb_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'pdbpp.py')
+pdb_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "pdbpp.py")
 
 # Set __file__ to exec'd code.  This is good in general, and required for
 # coverage.py to use it.
 __file__ = pdb_path
 
 with open(pdb_path) as f:
-    exec(compile(f.read(), pdb_path, 'exec'))
+    exec(compile(f.read(), pdb_path, "exec"))
 
 # Update/set __file__ attribute to actually sourced file, but not when not coming
 # here via "-m pdb", where __name__ is "__main__".

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1483,28 +1483,6 @@ except for when using the function decorator.
         ns.update(self.curframe_locals)
         code.interact("*interactive*", local=ns)
 
-    def do_track(self, arg):
-        """
-        track expression
-
-        Display a graph showing which objects are referred by the
-        value of the expression.  This command requires pypy to be in
-        the current PYTHONPATH.
-        """
-        try:
-            from rpython.translator.tool.reftracker import track
-        except ImportError:
-            print(
-                "** cannot import pypy.translator.tool.reftracker **", file=self.stdout
-            )
-            return
-        try:
-            val = self._getval(arg)
-        except:
-            pass
-        else:
-            track(val)
-
     def _get_display_list(self):
         return self.display_list.setdefault(self.curframe, {})
 

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -534,9 +534,8 @@ class Pdb(pdb.Pdb, ConfigurableClass, metaclass=PdbMeta):
     def print_hidden_frames_count(self):
         n = len(self._hidden_frames)
         if n and self.config.show_hidden_frames_count:
-            plural = n > 1 and "s" or ""
             print(
-                "   %d frame%s hidden (try 'help hidden_frames')" % (n, plural),
+                f"   {n} frame{'s' if n>1 else ''} hidden (try 'help hidden_frames')",
                 file=self.stdout,
             )
 

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -117,7 +117,6 @@ class DefaultConfig:
     editor = None  # Autodetected if unset.
     stdin_paste = None  # for emacs, you can use my bin/epaste script
     truncate_long_lines = True
-    exec_if_unfocused = None
     disable_pytest_capturing = False
     encodings = ("utf-8", "latin-1")
 
@@ -441,8 +440,6 @@ class Pdb(pdb.Pdb, ConfigurableClass, metaclass=PdbMeta):
             # a command like "continue")
             self.forget()
             return
-        if self.config.exec_if_unfocused:
-            self.exec_if_unfocused()
 
         # Handle post mortem via main: add exception similar to user_exception.
         if frame is None and traceback:
@@ -542,24 +539,6 @@ class Pdb(pdb.Pdb, ConfigurableClass, metaclass=PdbMeta):
                 "   %d frame%s hidden (try 'help hidden_frames')" % (n, plural),
                 file=self.stdout,
             )
-
-    def exec_if_unfocused(self):
-        import os
-
-        import wmctrl
-
-        term = os.getenv("TERM", "")
-        try:
-            winid = int(os.getenv("WINDOWID"))
-        except (TypeError, ValueError):
-            return  # cannot find WINDOWID of the terminal
-        active_win = wmctrl.Window.get_active()
-        if (
-            not active_win
-            or (int(active_win.id, 16) != winid)
-            and not (active_win.wm_class == "emacs.Emacs" and term.startswith("eterm"))
-        ):
-            os.system(self.config.exec_if_unfocused)
 
     def setup(self, frame, tb):
         ret = super().setup(frame, tb)

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -195,10 +195,10 @@ class ArgWithCount(str):
         return obj
 
     def __repr__(self):
-        return "<{} cmd_count={!r} value={}>".format(
-            self.__class__.__name__,
-            self.cmd_count,
-            super().__repr__(),
+        return (
+            f"<{self.__class__.__name__}"
+            f" cmd_count={self.cmd_count!r}"
+            f" value={super().__repr__()}>"
         )
 
 

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -30,8 +30,7 @@ from fancycompleter import Color, Completer, ConfigurableClass
 
 __author__ = "Antonio Cuni <anto.cuni@gmail.com>"
 __url__ = "http://github.com/antocuni/pdb"
-__version__ = fancycompleter.LazyVersion("pdbpp")
-
+from pdbpp_utils import __version__
 
 # If it contains only _, digits, letters, [] or dots, it's probably side
 # effects free.

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -92,6 +92,12 @@ def rebind_globals(func, newglobals):
             _newfunc(func.func, newglobals), *func.args, **func.keywords
         )
 
+    if sys.version_info >= (3, 11) and func.__name__ in (
+        "_ModuleTarget",
+        "_ScriptTarget",
+    ):
+        return func
+
     raise ValueError(f"cannot handle func {func}")
 
 
@@ -2154,10 +2160,13 @@ if hasattr(pdb, "_usage"):
     _usage = pdb._usage
 
 # copy some functions from pdb.py, but rebind the global dictionary
-for name in "run runeval runctx runcall main set_trace".split():
+to_rebind = ["run", "runeval", "runctx", "runcall", "main", "set_trace"]
+if sys.version_info >= (3, 11):
+    to_rebind += ["_ModuleTarget", "_ScriptTarget"]
+for name in to_rebind:
     func = getattr(pdb, name)
     globals()[name] = rebind_globals(func, globals())
-del name, func
+del name, func, to_rebind
 
 
 # Post-Mortem interface

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -316,7 +316,7 @@ class PdbMeta(type):
         _env = getattr(obj, "_env", None)
         if _env is not None and _env.get("HOME") != os.environ.get("HOME"):
             return False
-        if type(obj) == C:
+        if type(obj) is C:
             return True
         if getattr(obj, "_use_global_pdb_for_class", None) == C:
             return True

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 pdb++, a drop-in replacement for pdb
 ====================================
@@ -7,78 +6,39 @@ This module extends the stdlib pdb in numerous ways: look at the README for
 more details on pdb++ features.
 """
 
-from __future__ import print_function
-
-import sys
-import os.path
-import inspect
 import code
 import codecs
 import contextlib
-import types
-import traceback
-import subprocess
-import threading
+import inspect
+import os.path
 import pprint
 import re
+import shlex
 import signal
+import subprocess
+import sys
+import threading
+import traceback
+import types
 from collections import OrderedDict
+from functools import lru_cache
+from inspect import signature
+from io import StringIO
 
 import fancycompleter
-import six
 from fancycompleter import Color, Completer, ConfigurableClass
 
-__author__ = 'Antonio Cuni <anto.cuni@gmail.com>'
-__url__ = 'http://github.com/antocuni/pdb'
-__version__ = fancycompleter.LazyVersion('pdbpp')
+__author__ = "Antonio Cuni <anto.cuni@gmail.com>"
+__url__ = "http://github.com/antocuni/pdb"
+__version__ = fancycompleter.LazyVersion("pdbpp")
 
-try:
-    from inspect import signature  # Python >= 3.3
-except ImportError:
-    try:
-        from funcsigs import signature
-    except ImportError:
-        def signature(obj):
-            return ' [pip install funcsigs to show the signature]'
-
-try:
-    from functools import lru_cache
-except ImportError:
-    from functools import wraps
-
-    def lru_cache(maxsize):
-        """Simple cache (with no maxsize basically) for py27 compatibility.
-
-        Given that pdb there uses linecache.getline for each line with
-        do_list a cache makes a big difference."""
-
-        def dec(fn, *args):
-            cache = {}
-
-            @wraps(fn)
-            def wrapper(*args):
-                key = args
-                try:
-                    ret = cache[key]
-                except KeyError:
-                    ret = cache[key] = fn(*args)
-                return ret
-
-            return wrapper
-
-        return dec
 
 # If it contains only _, digits, letters, [] or dots, it's probably side
 # effects free.
-side_effects_free = re.compile(r'^ *[_0-9a-zA-Z\[\].]* *$')
+side_effects_free = re.compile(r"^ *[_0-9a-zA-Z\[\].]* *$")
 
 RE_COLOR_ESCAPES = re.compile("(\x1b[^m]+m)+")
 RE_REMOVE_FANCYCOMPLETER_ESCAPE_SEQS = re.compile(r"\x1b\[[\d;]+m")
-
-if sys.version_info < (3, ):
-    from io import BytesIO as StringIO
-else:
-    from io import StringIO
 
 
 local = threading.local()
@@ -87,7 +47,7 @@ local._pdbpp_completing = False
 local._pdbpp_in_init = False
 
 
-def __getattr__(name):
+def __getattr__(name):  # FIXME: ???
     """Backward compatibility (Python 3.7+)"""
     if name == "GLOBAL_PDB":
         return local.GLOBAL_PDB
@@ -96,27 +56,28 @@ def __getattr__(name):
 
 def import_from_stdlib(name):
     import code  # arbitrary module which stays in the same dir as pdb
+
     result = types.ModuleType(name)
 
     stdlibdir, _ = os.path.split(code.__file__)
-    pyfile = os.path.join(stdlibdir, name + '.py')
+    pyfile = os.path.join(stdlibdir, name + ".py")
     with open(pyfile) as f:
         src = f.read()
-    co_module = compile(src, pyfile, 'exec', dont_inherit=True)
+    co_module = compile(src, pyfile, "exec", dont_inherit=True)
     exec(co_module, result.__dict__)
 
     return result
 
 
-pdb = import_from_stdlib('pdb')
+pdb = import_from_stdlib("pdb")
 
 
 def _newfunc(func, newglobals):
-    newfunc = types.FunctionType(func.__code__, newglobals, func.__name__,
-                                 func.__defaults__, func.__closure__)
-    if sys.version_info >= (3, ):
-        newfunc.__annotations__ = func.__annotations__
-        newfunc.__kwdefaults__ = func.__kwdefaults__
+    newfunc = types.FunctionType(
+        func.__code__, newglobals, func.__name__, func.__defaults__, func.__closure__
+    )
+    newfunc.__annotations__ = func.__annotations__
+    newfunc.__kwdefaults__ = func.__kwdefaults__
     return newfunc
 
 
@@ -134,8 +95,8 @@ def rebind_globals(func, newglobals):
     raise ValueError("cannot handle func {!r}".format(func))
 
 
-class DefaultConfig(object):
-    prompt = '(Pdb++) '
+class DefaultConfig:
+    prompt = "(Pdb++) "
     highlight = True
     sticky_by_default = False
 
@@ -144,15 +105,15 @@ class DefaultConfig(object):
     pygments_formatter_class = None  # Defaults to autodetect, based on $TERM.
     pygments_formatter_kwargs = {}
     # Legacy options.  Should use pygments_formatter_kwargs instead.
-    bg = 'dark'
+    bg = "dark"
     colorscheme = None
 
     editor = None  # Autodetected if unset.
-    stdin_paste = None       # for emacs, you can use my bin/epaste script
+    stdin_paste = None  # for emacs, you can use my bin/epaste script
     truncate_long_lines = True
     exec_if_unfocused = None
     disable_pytest_capturing = False
-    encodings = ('utf-8', 'latin-1')
+    encodings = ("utf-8", "latin-1")
 
     enable_hidden_frames = True
     show_hidden_frames_count = True
@@ -165,8 +126,7 @@ class DefaultConfig(object):
     show_traceback_on_error_limit = None
 
     # Default keyword arguments passed to ``Pdb`` constructor.
-    default_pdb_kwargs = {
-    }
+    default_pdb_kwargs = {}
 
     def setup(self, pdb):
         pass
@@ -179,10 +139,11 @@ def setbgcolor(line, color):
     # hack hack hack
     # add a bgcolor attribute to all escape sequences found
     import re
-    setbg = '\x1b[%sm' % color
-    regexbg = '\\1;%sm' % color
-    result = setbg + re.sub('(\x1b\\[.*?)m', regexbg, line) + '\x1b[00m'
-    if os.environ.get('TERM') == 'eterm-color':
+
+    setbg = "\x1b[%sm" % color
+    regexbg = "\\1;%sm" % color
+    result = setbg + re.sub("(\x1b\\[.*?)m", regexbg, line) + "\x1b[00m"
+    if os.environ.get("TERM") == "eterm-color":
         # it seems that emacs' terminal has problems with some ANSI escape
         # sequences. Eg, 'ESC[44m' sets the background color in all terminals
         # I tried, but not in emacs. To set the background color, it needs to
@@ -193,17 +154,18 @@ def setbgcolor(line, color):
         # want to change it.  These lines seems to work fine with the ANSI
         # codes produced by pygments, but they are surely not a general
         # solution.
-        result = result.replace(setbg, '\x1b[37;%dm' % color)
-        result = result.replace('\x1b[00;%dm' % color, '\x1b[37;%dm' % color)
-        result = result.replace('\x1b[39;49;00;', '\x1b[37;')
+        result = result.replace(setbg, "\x1b[37;%dm" % color)
+        result = result.replace("\x1b[00;%dm" % color, "\x1b[37;%dm" % color)
+        result = result.replace("\x1b[39;49;00;", "\x1b[37;")
     return result
 
 
-CLEARSCREEN = '\033[2J\033[1;1H'
+CLEARSCREEN = "\033[2J\033[1;1H"
 
 
 def lasti2lineno(code, lasti):
     import dis
+
     linestarts = list(dis.findlinestarts(code))
     linestarts.reverse()
     for i, lineno in linestarts:
@@ -214,7 +176,7 @@ def lasti2lineno(code, lasti):
 
 class Undefined:
     def __repr__(self):
-        return '<undefined>'
+        return "<undefined>"
 
 
 undefined = Undefined()
@@ -222,8 +184,9 @@ undefined = Undefined()
 
 class ArgWithCount(str):
     """Extend arguments with a count, e.g. "10pp …"."""
+
     def __new__(cls, value, count, **kwargs):
-        obj = super(ArgWithCount, cls).__new__(cls, value)
+        obj = super().__new__(cls, value)
         obj.cmd_count = count
         return obj
 
@@ -231,7 +194,7 @@ class ArgWithCount(str):
         return "<{} cmd_count={!r} value={}>".format(
             self.__class__.__name__,
             self.cmd_count,
-            super(ArgWithCount, self).__repr__(),
+            super().__repr__(),
         )
 
 
@@ -241,12 +204,14 @@ class PdbMeta(type):
 
         # Prevent recursion errors with pdb.set_trace() during init/debugging.
         if getattr(local, "_pdbpp_in_init", False):
-            class OrigPdb(pdb.Pdb, object):
+
+            class OrigPdb(pdb.Pdb):
                 def set_trace(self, frame=None):
                     print("pdb++: using pdb.Pdb for recursive set_trace.")
                     if frame is None:
                         frame = sys._getframe().f_back
-                    super(OrigPdb, self).set_trace(frame)
+                    super().set_trace(frame)
+
             orig_pdb = OrigPdb.__new__(OrigPdb)
             # Remove any pdb++ only kwargs.
             kwargs.pop("Config", None)
@@ -316,12 +281,10 @@ class PdbMeta(type):
         _env = getattr(obj, "_env", None)
         if _env is not None and _env.get("HOME") != os.environ.get("HOME"):
             return False
-        if type(obj) is C:
+        if type(obj) == C:
             return True
         if getattr(obj, "_use_global_pdb_for_class", None) == C:
             return True
-        if sys.version_info < (3, 3):
-            return inspect.getsourcelines(obj.__class__) == inspect.getsourcelines(C)
         return C.__qualname__ == obj.__class__.__qualname__
 
     @staticmethod
@@ -340,20 +303,18 @@ class PdbMeta(type):
         return called_for_set_trace
 
 
-@six.add_metaclass(PdbMeta)
-class Pdb(pdb.Pdb, ConfigurableClass, object):
-
+class Pdb(pdb.Pdb, ConfigurableClass, metaclass=PdbMeta):
     DefaultConfig = DefaultConfig
-    config_filename = '.pdbrc.py'
+    config_filename = ".pdbrc.py"
     disabled = False
     fancycompleter = None
 
     _in_interaction = False
 
     def __init__(self, *args, **kwds):
-        self.ConfigFactory = kwds.pop('Config', None)
-        self.start_lineno = kwds.pop('start_lineno', None)
-        self.start_filename = kwds.pop('start_filename', None)
+        self.ConfigFactory = kwds.pop("Config", None)
+        self.start_lineno = kwds.pop("start_lineno", None)
+        self.start_filename = kwds.pop("start_filename", None)
 
         self.config = self.get_config(self.ConfigFactory)
         self.config.setup(self)
@@ -366,7 +327,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             self._disable_pytest_capture_maybe()
         kwargs = self.config.default_pdb_kwargs.copy()
         kwargs.update(**kwds)
-        super(Pdb, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.prompt = self.config.prompt
         self.display_list = {}  # frame --> (name --> last seen value)
         self.tb_lineno = {}  # frame --> lineno where the exception raised
@@ -402,22 +363,25 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
     def ensure_file_can_write_unicode(self, f):
         # Wrap with an encoder, but only if not already wrapped
-        if (not hasattr(f, 'stream')
-                and getattr(f, 'encoding', False)
-                and f.encoding.lower() != 'utf-8'):
-            f = codecs.getwriter('utf-8')(getattr(f, 'buffer', f))
+        if (
+            not hasattr(f, "stream")
+            and getattr(f, "encoding", False)
+            and f.encoding.lower() != "utf-8"
+        ):
+            f = codecs.getwriter("utf-8")(getattr(f, "buffer", f))
 
         return f
 
     def _disable_pytest_capture_maybe(self):
         try:
             import py.test
+
             # Force raising of ImportError if pytest is not installed.
             py.test.config
         except (ImportError, AttributeError):
             return
         try:
-            capman = py.test.config.pluginmanager.getplugin('capturemanager')
+            capman = py.test.config.pluginmanager.getplugin("capturemanager")
             capman.suspendcapture()
         except KeyError:
             pass
@@ -458,7 +422,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
     def _interaction(self, frame, traceback):
         # Restore the previous signal handler at the Pdb prompt.
-        if getattr(pdb.Pdb, '_previous_sigint_handler', None):
+        if getattr(pdb.Pdb, "_previous_sigint_handler", None):
             try:
                 signal.signal(signal.SIGINT, pdb.Pdb._previous_sigint_handler)
             except ValueError:  # ValueError: signal only works in main thread
@@ -478,7 +442,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         if frame is None and traceback:
             exc = sys.exc_info()[:2]
             if exc != (None, None):
-                self.curframe.f_locals['__exception__'] = exc
+                self.curframe.f_locals["__exception__"] = exc
 
         if not self.sticky:
             self.print_stack_entry(self.stack[self.curindex])
@@ -487,7 +451,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         with self._custom_completer():
             self.config.before_interaction_hook(self)
             # Use _cmdloop on py3 which catches KeyboardInterrupt.
-            if hasattr(self, '_cmdloop'):
+            if hasattr(self, "_cmdloop"):
                 self._cmdloop()
             else:
                 self.cmdloop()
@@ -495,7 +459,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         self.forget()
 
     def break_here(self, frame):
-        ret = super(Pdb, self).break_here(frame)
+        ret = super().break_here(frame)
         if ret:
             # Skip clearing screen if invoked via breakpoint, which e.g.
             # might execute/display output from commands.
@@ -515,7 +479,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
     def postcmd(self, stop, line):
         """Handle clearing of the screen for sticky mode."""
-        stop = super(Pdb, self).postcmd(stop, line)
+        stop = super().postcmd(stop, line)
         if self.sticky:
             if stop and not self.commands_defining:
                 self._sticky_handle_cls()
@@ -533,12 +497,12 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
     def set_continue(self):
         if self.sticky:
             self._sticky_skip_cls = True
-        super(Pdb, self).set_continue()
+        super().set_continue()
 
     def set_quit(self):
         if self.sticky:
             self._sticky_skip_cls = True
-        super(Pdb, self).set_quit()
+        super().set_quit()
 
     def _setup_fancycompleter(self):
         """Similar to fancycompleter.setup(), but returning the old completer."""
@@ -550,7 +514,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         if fancycompleter.has_leopard_libedit(completer.config):
             readline.parse_and_bind("bind ^I rl_complete")
         else:
-            readline.parse_and_bind('tab: complete')
+            readline.parse_and_bind("tab: complete")
         readline.set_completer(self.complete)
         return old_completer
 
@@ -575,19 +539,24 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
     def exec_if_unfocused(self):
         import os
+
         import wmctrl
-        term = os.getenv('TERM', '')
+
+        term = os.getenv("TERM", "")
         try:
-            winid = int(os.getenv('WINDOWID'))
+            winid = int(os.getenv("WINDOWID"))
         except (TypeError, ValueError):
             return  # cannot find WINDOWID of the terminal
         active_win = wmctrl.Window.get_active()
-        if not active_win or (int(active_win.id, 16) != winid) and \
-           not (active_win.wm_class == 'emacs.Emacs' and term.startswith('eterm')):
+        if (
+            not active_win
+            or (int(active_win.id, 16) != winid)
+            and not (active_win.wm_class == "emacs.Emacs" and term.startswith("eterm"))
+        ):
             os.system(self.config.exec_if_unfocused)
 
     def setup(self, frame, tb):
-        ret = super(Pdb, self).setup(frame, tb)
+        ret = super().setup(frame, tb)
         if not ret:
             while tb:
                 lineno = lasti2lineno(tb.tb_frame.f_code, tb.tb_lasti)
@@ -608,7 +577,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         if frame is getattr(self, "_via_set_trace_frame", None):
             return False
 
-        if frame.f_globals.get('__unittest'):
+        if frame.f_globals.get("__unittest"):
             return True
 
         # `f_locals` might be a list (checked via PyMapping_Check).
@@ -623,7 +592,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
     def get_stack(self, f, t):
         # show all the frames, except the ones that explicitly ask to be hidden
-        fullstack, idx = super(Pdb, self).get_stack(f, t)
+        fullstack, idx = super().get_stack(f, t)
         self.fullstack = fullstack
         return self.compute_stack(fullstack, idx)
 
@@ -658,7 +627,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
                 self.curindex = i
                 break
         else:
-            self.curindex = len(self.stack)-1
+            self.curindex = len(self.stack) - 1
             self.curframe = self.stack[-1][0]
             self.print_current_stack_entry()
 
@@ -672,7 +641,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
     def forget(self):
         if not getattr(local, "_pdbpp_completing", False):
-            super(Pdb, self).forget()
+            super().forget()
 
     @classmethod
     def _get_all_completions(cls, complete, text):
@@ -707,7 +676,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         try:
             return self._complete(text, state)
         except Exception as exc:
-            self.error("error during completion: {}".format(exc))
+            self.error(f"error during completion: {exc}")
             if self.config.show_traceback_on_error:
                 __import__("traceback").print_exc(file=self.stdout)
 
@@ -725,17 +694,19 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             completions = self._get_all_completions(completer.complete, text)
 
             if self.fancycompleter.config.use_colors:
-                clean_fancy_completions = set([
-                    RE_REMOVE_FANCYCOMPLETER_ESCAPE_SEQS.sub("", x)
-                    for x in completions
-                ])
+                clean_fancy_completions = set(
+                    [
+                        RE_REMOVE_FANCYCOMPLETER_ESCAPE_SEQS.sub("", x)
+                        for x in completions
+                    ]
+                )
             else:
                 clean_fancy_completions = completions
 
             # Get completions from original pdb.
             pdb_completions = []
             with self._patch_readline_for_pyrepl():
-                real_pdb = super(Pdb, self)
+                real_pdb = super()
                 for x in self._get_all_completions(real_pdb.complete, text):
                     if x not in clean_fancy_completions:
                         pdb_completions.append(x)
@@ -748,10 +719,10 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             self._completions = completions
             if pdb_completions:
                 pdb_prefix = fancycompleter.commonprefix(pdb_completions)
-                if '.' in text and pdb_prefix and len(pdb_completions) > 1:
+                if "." in text and pdb_prefix and len(pdb_completions) > 1:
                     # Remove prefix for attr_matches from pdb completions.
-                    dotted = text.split('.')
-                    prefix = '.'.join(dotted[:-1]) + '.'
+                    dotted = text.split(".")
+                    prefix = ".".join(dotted[:-1]) + "."
                     prefix_len = len(prefix)
                     pdb_completions = [
                         x[prefix_len:] if x.startswith(prefix) else x
@@ -790,21 +761,17 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
         if text[-1:] != "_":
             self._completions = [
-                x
-                for x in self._completions
-                if RE_COLOR_ESCAPES.sub("", x)[:1] != "_"
+                x for x in self._completions if RE_COLOR_ESCAPES.sub("", x)[:1] != "_"
             ]
         elif text[-2:] != "__":
             self._completions = [
-                x
-                for x in self._completions
-                if RE_COLOR_ESCAPES.sub("", x)[:2] != "__"
+                x for x in self._completions if RE_COLOR_ESCAPES.sub("", x)[:2] != "__"
             ]
 
-    stack_entry_regexp = re.compile(r'(.*?)\(([0-9]+?)\)(.*)', re.DOTALL)
+    stack_entry_regexp = re.compile(r"(.*?)\(([0-9]+?)\)(.*)", re.DOTALL)
 
-    def format_stack_entry(self, frame_lineno, lprefix=': '):
-        entry = super(Pdb, self).format_stack_entry(frame_lineno, lprefix)
+    def format_stack_entry(self, frame_lineno, lprefix=": "):
+        entry = super().format_stack_entry(frame_lineno, lprefix)
         entry = self.try_to_decode(entry)
         if self.config.highlight:
             match = self.stack_entry_regexp.match(entry)
@@ -812,7 +779,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
                 filename, lineno, other = match.groups()
                 filename = Color.set(self.config.filename_color, filename)
                 lineno = Color.set(self.config.line_number_color, lineno)
-                entry = '%s(%s)%s' % (filename, lineno, other)
+                entry = f"{filename}({lineno}){other}"
         if self.config.use_pygments is not False:
             loc, _, source = entry.rpartition(lprefix)
             if _:
@@ -845,9 +812,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         try:
             pygments_formatter = self._get_pygments_formatter()
         except Exception as exc:
-            self.message("pdb++: could not setup Pygments, disabling: {}".format(
-                exc
-            ))
+            self.message("pdb++: could not setup Pygments, disabling: {}".format(exc))
             return False
 
         lexer = pygments.lexers.PythonLexer(stripnl=False)
@@ -858,7 +823,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         return syntax_highlight
 
     def _get_pygments_formatter(self):
-        if hasattr(self.config, 'formatter'):
+        if hasattr(self.config, "formatter"):
             # Deprecated, never documented.
             # Not optimal, since it involves creating the formatter in
             # the config already, although it might never be used.
@@ -868,7 +833,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             from importlib import import_module
 
             def import_string(dotted_path):
-                module_path, class_name = dotted_path.rsplit('.', 1)
+                module_path, class_name = dotted_path.rsplit(".", 1)
                 module = import_module(module_path)
                 return getattr(module, class_name)
 
@@ -922,36 +887,36 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         return self._highlight(src)
 
     def _format_line(self, lineno, marker, line, lineno_width):
-        lineno = ('%%%dd' % lineno_width) % lineno
+        lineno = ("%%%dd" % lineno_width) % lineno
         if self.config.highlight:
             lineno = Color.set(self.config.line_number_color, lineno)
-        line = '%s  %2s %s' % (lineno, marker, line)
+        line = "%s  %2s %s" % (lineno, marker, line)
         return line
 
     def execRcLines(self):
         self._pdbpp_executing_rc_lines = True
         try:
-            return super(Pdb, self).execRcLines()
+            return super().execRcLines()
         finally:
             del self._pdbpp_executing_rc_lines
 
     def parseline(self, line):
         if getattr(self, "_pdbpp_executing_rc_lines", False):
-            return super(Pdb, self).parseline(line)
+            return super().parseline(line)
 
-        if line.startswith('!!'):
+        if line.startswith("!!"):
             # Force the "standard" behaviour, i.e. first check for the
             # command, then for the variable name to display.
             line = line[2:]
-            cmd, arg, newline = super(Pdb, self).parseline(line)
+            cmd, arg, newline = super().parseline(line)
             return cmd, arg, "!!" + newline
 
-        if line.endswith('?') and not line.startswith("!"):
-            arg = line.split('?', 1)[0]
-            if line.endswith('??'):
+        if line.endswith("?") and not line.startswith("!"):
+            arg = line.split("?", 1)[0]
+            if line.endswith("??"):
                 cmd = "inspect_with_source"
-            elif arg == '' or (
-                hasattr(self, 'do_' + arg)
+            elif arg == "" or (
+                hasattr(self, "do_" + arg)
                 and arg not in self.curframe.f_globals
                 and arg not in self.curframe_locals
             ):
@@ -963,7 +928,7 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         # pdb++ "smart command mode": don't execute commands if a variable
         # with the name exists in the current context;
         # This prevents pdb to quit if you type e.g. 'r[0]' by mistake.
-        cmd, arg, newline = super(Pdb, self).parseline(line)
+        cmd, arg, newline = super().parseline(line)
 
         if cmd:
             # prefixed strings.
@@ -1022,42 +987,44 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
             return
 
         data = OrderedDict()
-        data['Type'] = type(obj).__name__
-        data['String Form'] = str(obj).strip()
+        data["Type"] = type(obj).__name__
+        data["String Form"] = str(obj).strip()
         try:
-            data['Length'] = str(len(obj))
+            data["Length"] = str(len(obj))
         except TypeError:
             pass
         try:
-            data['File'] = inspect.getabsfile(obj)
+            data["File"] = inspect.getabsfile(obj)
         except TypeError:
             pass
         else:
             try:
-                data['File'] += ":" + str(obj.__code__.co_firstlineno)
+                data["File"] += ":" + str(obj.__code__.co_firstlineno)
             except AttributeError:
                 pass
 
-        if (isinstance(obj, type)
-                and hasattr(obj, '__init__')
-                and getattr(obj, '__module__') != '__builtin__'):
+        if (
+            isinstance(obj, type)
+            and hasattr(obj, "__init__")
+            and getattr(obj, "__module__") != "__builtin__"
+        ):
             # Class - show definition and docstring for constructor
-            data['Docstring'] = inspect.getdoc(obj)
-            data['Constructor information'] = ''
+            data["Docstring"] = inspect.getdoc(obj)
+            data["Constructor information"] = ""
             try:
-                data['  Definition'] = '%s%s' % (arg, signature(obj))
+                data["  Definition"] = "%s%s" % (arg, signature(obj))
             except ValueError:
                 pass
-            data['  Docstring'] = inspect.getdoc(obj.__init__)
+            data["  Docstring"] = inspect.getdoc(obj.__init__)
         else:
             try:
-                data['Definition'] = '%s%s' % (arg, signature(obj))
+                data["Definition"] = "%s%s" % (arg, signature(obj))
             except (TypeError, ValueError):
                 pass
-            data['Docstring'] = inspect.getdoc(obj)
+            data["Docstring"] = inspect.getdoc(obj)
 
         for key, value in data.items():
-            formatted_key = Color.set(Color.red, key + ':')
+            formatted_key = Color.set(Color.red, key + ":")
             if value is None:
                 continue
             if value:
@@ -1066,12 +1033,11 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
                 if lines:
                     indent = " " * 16
                     formatted_value += "\n" + "\n".join(
-                        indent + line
-                        for line in lines.splitlines()
+                        indent + line for line in lines.splitlines()
                     )
             else:
                 formatted_value = ""
-            self.stdout.write('%-28s %s\n' % (formatted_key, formatted_value))
+            self.stdout.write("%-28s %s\n" % (formatted_key, formatted_value))
 
         if with_source:
             self.stdout.write("%-28s" % Color.set(Color.red, "Source:"))
@@ -1088,13 +1054,13 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
         Fixes https://bugs.python.org/issue21161.
         """
         self.history.append(line)
-        if line[:1] == '!':
+        if line[:1] == "!":
             line = line[1:]
         locals = self.curframe_locals
         ns = self.curframe.f_globals.copy()
         ns.update(locals)
         try:
-            code = compile(line + '\n', '<stdin>', 'single')
+            code = compile(line + "\n", "<stdin>", "single")
             save_stdout = sys.stdout
             save_stdin = sys.stdin
             save_displayhook = sys.displayhook
@@ -1113,14 +1079,15 @@ class Pdb(pdb.Pdb, ConfigurableClass, object):
 
     def do_help(self, arg):
         try:
-            return super(Pdb, self).do_help(arg)
+            return super().do_help(arg)
         except AttributeError:
-            print("*** No help for '{command}'".format(command=arg),
-                  file=self.stdout)
+            print("*** No help for '{command}'".format(command=arg), file=self.stdout)
+
     do_help.__doc__ = pdb.Pdb.do_help.__doc__
 
     def help_hidden_frames(self):
-        print("""\
+        print(
+            """\
 Some frames might be marked as "hidden": by default, hidden frames are not
 shown in the stack trace, and cannot be reached using ``up`` and ``down``.
 You can use ``hf_unhide`` to tell pdb++ to ignore the hidden status (i.e., to
@@ -1142,7 +1109,9 @@ Frames can be marked as hidden in the following ways:
 
 Note that the initial frame where ``set_trace`` was called from is not hidden,
 except for when using the function decorator.
-""", file=self.stdout)
+""",
+            file=self.stdout,
+        )
 
     def do_hf_unhide(self, arg):
         """
@@ -1163,8 +1132,9 @@ except for when using the function decorator.
 
     def do_hf_list(self, arg):
         for frame_lineno in self._hidden_frames:
-            print(self.format_stack_entry(frame_lineno, pdb.line_prefix),
-                  file=self.stdout)
+            print(
+                self.format_stack_entry(frame_lineno, pdb.line_prefix), file=self.stdout
+            )
 
     def do_longlist(self, arg):
         """
@@ -1179,14 +1149,14 @@ except for when using the function decorator.
         If the 'highlight' config option is set and pygments is
         installed, the source code is colorized.
         """
-        self.lastcmd = 'longlist'
+        self.lastcmd = "longlist"
         self._printlonglist(max_lines=False)
 
     do_ll = do_longlist
 
     def _printlonglist(self, linerange=None, max_lines=None):
         try:
-            if self.curframe.f_code.co_name == '<module>':
+            if self.curframe.f_code.co_name == "<module>":
                 # inspect.getsourcelines is buggy in this case: if we just
                 # pass the frame, it returns the source for the first function
                 # defined in the module.  Instead, we want the full source
@@ -1197,17 +1167,19 @@ except for when using the function decorator.
                 try:
                     lines, lineno = inspect.getsourcelines(self.curframe)
                 except Exception as e:
-                    print('** Error in inspect.getsourcelines: %s **' %
-                          e, file=self.stdout)
+                    print(
+                        "** Error in inspect.getsourcelines: %s **" % e,
+                        file=self.stdout,
+                    )
                     return
-        except IOError as e:
-            print('** Error: %s **' % e, file=self.stdout)
+        except OSError as e:
+            print("** Error: %s **" % e, file=self.stdout)
             return
         if linerange:
             start, end = linerange
             start = max(start, lineno)
-            end = min(end, lineno+len(lines))
-            lines = lines[start-lineno:end-lineno]
+            end = min(end, lineno + len(lines))
+            lines = lines[start - lineno : end - lineno]
             lineno = start
         self._print_lines_pdbpp(lines, lineno, max_lines=max_lines)
 
@@ -1241,7 +1213,7 @@ except for when using the function decorator.
         else:
             assert maxlength - total_visible_len > 0
             rest = s[m_end:]
-            ret += rest[:maxlength - total_visible_len]
+            ret += rest[: maxlength - total_visible_len]
 
         # Keep reset sequence (in last match).
         if len(ret) != len(s):
@@ -1267,10 +1239,9 @@ except for when using the function decorator.
         # Keeps decorators, but not functions, which are displayed at the top
         # already (stack information).
         # TODO: check behavior with lambdas.
-        COLOR_OR_SPACE = r'(?:\x1b[^m]+m|\s)'
+        COLOR_OR_SPACE = r"(?:\x1b[^m]+m|\s)"
         keep_pat = re.compile(
-            r'(?:^{col}*@)'
-            r'|(?<!\w)lambda(?::|{col})'.format(col=COLOR_OR_SPACE)
+            r"(?:^{col}*@)" r"|(?<!\w)lambda(?::|{col})".format(col=COLOR_OR_SPACE)
         )
         keep_head = 0
         while keep_pat.match(lines[keep_head]):
@@ -1278,17 +1249,17 @@ except for when using the function decorator.
 
         if keep_head > 3:
             yield lineno, lines[0]
-            yield None, '...'
-            yield lineno + keep_head, lines[keep_head-1]
+            yield None, "..."
+            yield lineno + keep_head, lines[keep_head - 1]
             cutoff -= keep_head - 3
         else:
             for i, line in enumerate(lines[:keep_head]):
                 yield lineno + i, line
 
         exc_lineno = self.tb_lineno.get(self.curframe, None)
-        last_marker_line = max(
-            self.curframe.f_lineno,
-            exc_lineno if exc_lineno else 0) - lineno
+        last_marker_line = (
+            max(self.curframe.f_lineno, exc_lineno if exc_lineno else 0) - lineno
+        )
 
         # Place marker / current line in first third of available lines.
         cut_before = min(
@@ -1306,29 +1277,29 @@ except for when using the function decorator.
             if cut_before:
                 cut_before -= 1
                 if cut_before == 0:
-                    yield None, '...'
+                    yield None, "..."
                 else:
                     assert cut_before > 0, cut_before
                 continue
             elif cut_after and i >= len(lines) - cut_after:
-                yield None, '...'
+                yield None, "..."
                 break
             yield lineno + i, line
 
     def _print_lines_pdbpp(self, lines, lineno, print_markers=True, max_lines=None):
         lines = [line[:-1] for line in lines]  # remove the trailing '\n'
-        lines = [line.replace('\t', '    ')
-                 for line in lines]  # force tabs to 4 spaces
+        lines = [line.replace("\t", "    ") for line in lines]  # force tabs to 4 spaces
         width, height = self.get_terminal_size()
 
         if self.config.use_pygments is not False:
-            src = self.format_source('\n'.join(lines))
+            src = self.format_source("\n".join(lines))
             lines = src.splitlines()
 
         if self.config.truncate_long_lines:
             maxlength = max(width - 9, 16)
-            lines = [self._truncate_to_visible_length(line, maxlength)
-                     for line in lines]
+            lines = [
+                self._truncate_to_visible_length(line, maxlength) for line in lines
+            ]
 
         lineno_width = len(str(lineno + len(lines)))
         exc_lineno = self.tb_lineno.get(self.curframe, None)
@@ -1342,11 +1313,11 @@ except for when using the function decorator.
                     continue
 
                 if lineno == self.curframe.f_lineno:
-                    marker = '->'
+                    marker = "->"
                 elif lineno == exc_lineno:
-                    marker = '>>'
+                    marker = ">>"
                 else:
-                    marker = ''
+                    marker = ""
                 line = self._format_line(lineno, marker, line, lineno_width)
 
                 if marker == "->" and set_bg:
@@ -1356,9 +1327,9 @@ except for when using the function decorator.
                 new_lines.append(line)
         else:
             for i, line in enumerate(lines):
-                new_lines.append(self._format_line(lineno, '', line, lineno_width))
+                new_lines.append(self._format_line(lineno, "", line, lineno_width))
                 lineno += 1
-        print('\n'.join(new_lines), file=self.stdout)
+        print("\n".join(new_lines), file=self.stdout)
 
     def _format_color_prefixes(self, lines):
         if not lines:
@@ -1372,7 +1343,7 @@ except for when using the function decorator.
         src_lines = []
 
         for x in lines:
-            prefix, _, src = x.partition('\t')
+            prefix, _, src = x.partition("\t")
             prefixes.append(prefix)
             src_lines.append(src)
 
@@ -1381,15 +1352,12 @@ except for when using the function decorator.
             prefixes = [
                 RE_LNUM_PREFIX.sub(
                     lambda m: Color.set(self.config.line_number_color, m.group(0)),
-                    prefix
+                    prefix,
                 )
                 for prefix in prefixes
             ]
 
-        return [
-            "%s\t%s" % (prefix, src)
-            for (prefix, src) in zip(prefixes, src_lines)
-        ]
+        return ["%s\t%s" % (prefix, src) for (prefix, src) in zip(prefixes, src_lines)]
 
     @contextlib.contextmanager
     def _patch_linecache_for_source_highlight(self):
@@ -1399,9 +1367,6 @@ except for when using the function decorator.
             """Wrap linecache.getlines to highlight source (for do_list)."""
             lines = orig(filename, globals)
             source = self.format_source("".join(lines))
-
-            if sys.version_info < (3,):
-                source = self.try_to_encode(source)
 
             return source.splitlines(True)
 
@@ -1415,13 +1380,12 @@ except for when using the function decorator.
     def do_list(self, arg):
         """Enhance original do_list with highlighting."""
         if not (self.config.use_pygments is not False or self.config.highlight):
-            return super(Pdb, self).do_list(arg)
+            return super().do_list(arg)
 
         with self._patch_linecache_for_source_highlight():
-
             oldstdout = self.stdout
             self.stdout = StringIO()
-            ret = super(Pdb, self).do_list(arg)
+            ret = super().do_list(arg)
             orig_pdb_lines = self.stdout.getvalue().splitlines()
             self.stdout = oldstdout
 
@@ -1442,12 +1406,13 @@ except for when using the function decorator.
         self.lineno = None
 
     def do_continue(self, arg):
-        if arg != '':
+        if arg != "":
             self._seen_error = False
             self.do_tbreak(arg)
             if self._seen_error:
                 return 0
-        return super(Pdb, self).do_continue('')
+        return super().do_continue("")
+
     do_continue.__doc__ = pdb.Pdb.do_continue.__doc__
     do_c = do_cont = do_continue
 
@@ -1485,6 +1450,7 @@ except for when using the function decorator.
         except:
             exc_info = sys.exc_info()[:2]
             self.error(traceback.format_exception_only(*exc_info)[-1].strip())
+
     do_pp.__doc__ = pdb.Pdb.do_pp.__doc__
 
     def do_debug(self, arg):
@@ -1503,7 +1469,7 @@ except for when using the function decorator.
         class PdbppWithConfig(self.__class__):
             def __init__(self_withcfg, *args, **kwargs):
                 kwargs.setdefault("Config", Config)
-                super(PdbppWithConfig, self_withcfg).__init__(*args, **kwargs)
+                super().__init__(*args, **kwargs)
 
                 # Backport of fix for bpo-31078 (not yet merged).
                 self_withcfg.use_rawinput = self.use_rawinput
@@ -1554,8 +1520,9 @@ except for when using the function decorator.
         try:
             from rpython.translator.tool.reftracker import track
         except ImportError:
-            print('** cannot import pypy.translator.tool.reftracker **',
-                  file=self.stdout)
+            print(
+                "** cannot import pypy.translator.tool.reftracker **", file=self.stdout
+            )
             return
         try:
             val = self._getval(arg)
@@ -1569,8 +1536,7 @@ except for when using the function decorator.
 
     def _getval_or_undefined(self, arg):
         try:
-            return eval(arg, self.curframe.f_globals,
-                        self.curframe_locals)
+            return eval(arg, self.curframe.f_globals, self.curframe_locals)
         except NameError:
             return undefined
 
@@ -1601,7 +1567,7 @@ except for when using the function decorator.
         try:
             del self._get_display_list()[arg]
         except KeyError:
-            print('** %s not in the display list **' % arg, file=self.stdout)
+            print("** %s not in the display list **" % arg, file=self.stdout)
 
     def _print_if_sticky(self):
         if self.sticky and not self.commands_defining:
@@ -1638,8 +1604,8 @@ except for when using the function decorator.
             sticky_range = self.sticky_ranges.get(self.curframe, None)
 
             after_lines = []
-            if '__exception__' in frame.f_locals:
-                s = self._format_exc_for_sticky(frame.f_locals['__exception__'])
+            if "__exception__" in frame.f_locals:
+                s = self._format_exc_for_sticky(frame.f_locals["__exception__"])
                 if s:
                     after_lines.append(s)
 
@@ -1648,16 +1614,16 @@ except for when using the function decorator.
                 if s:
                     after_lines.append(s)
 
-            elif '__return__' in frame.f_locals:
-                rv = frame.f_locals['__return__']
+            elif "__return__" in frame.f_locals:
+                rv = frame.f_locals["__return__"]
                 try:
                     s = repr(rv)
                 except KeyboardInterrupt:
                     raise
                 except:
-                    s = '(unprintable return value)'
+                    s = "(unprintable return value)"
 
-                s = ' return ' + s
+                s = " return " + s
                 if self.config.highlight:
                     s = Color.set(self.config.line_number_color, s)
                 after_lines.append(s)
@@ -1685,28 +1651,28 @@ except for when using the function decorator.
             return "pdbpp: got unexpected __exception__: %r" % (exc,)
 
         exc_type, exc_value = exc
-        s = ''
+        s = ""
         try:
             try:
                 s = exc_type.__name__
             except AttributeError:
                 s = str(exc_type)
             if exc_value is not None:
-                s += ': '
+                s += ": "
                 s += str(exc_value)
         except KeyboardInterrupt:
             raise
         except Exception as exc:
             try:
-                s += '(unprintable exception: %r)' % (exc,)
+                s += "(unprintable exception: %r)" % (exc,)
             except:
-                s += '(unprintable exception)'
+                s += "(unprintable exception)"
         else:
             # Use first line only, limited to terminal width.
             s = s.replace("\r", r"\r").replace("\n", r"\n")
             width, _ = self.get_terminal_size()
             if len(s) > width:
-                s = s[:width - 1] + "…"
+                s = s[: width - 1] + "…"
 
         if self.config.highlight:
             s = Color.set(self.config.line_number_color, s)
@@ -1731,11 +1697,10 @@ except for when using the function decorator.
             try:
                 start, end = map(int, arg.split())
             except ValueError:
-                print('** Error when parsing argument: %s **' % arg,
-                      file=self.stdout)
+                print("** Error when parsing argument: %s **" % arg, file=self.stdout)
                 return
             self.sticky = True
-            self.sticky_ranges[self.curframe] = start, end+1
+            self.sticky_ranges[self.curframe] = start, end + 1
         else:
             self.sticky = not self.sticky
             self.sticky_range = None
@@ -1804,8 +1769,7 @@ except for when using the function decorator.
             # whose fields are changed to be displayed
             if newvalue is not oldvalue or newvalue != oldvalue:
                 display_list[expr] = newvalue
-                print('%s: %r --> %r' % (expr, oldvalue, newvalue),
-                      file=self.stdout)
+                print("%s: %r --> %r" % (expr, oldvalue, newvalue), file=self.stdout)
 
     def _get_position_of_arg(self, arg, quiet=False):
         try:
@@ -1850,9 +1814,9 @@ except for when using the function decorator.
         try:
             filename = inspect.getabsfile(obj)
             lines, lineno = inspect.getsourcelines(obj)
-        except (IOError, TypeError) as e:
+        except (OSError, TypeError) as e:
             if not quiet:
-                self.error('could not get obj: {}'.format(e))
+                self.error("could not get obj: {}".format(e))
             return None, None, None
         return filename, lineno, lines
 
@@ -1876,11 +1840,10 @@ except for when using the function decorator.
         try:
             arg = int(arg)
         except (ValueError, TypeError):
-            print(
-                '*** Expected a number, got "{0}"'.format(arg), file=self.stdout)
+            print('*** Expected a number, got "{}"'.format(arg), file=self.stdout)
             return
         if abs(arg) >= len(self.stack):
-            print('*** Out of range', file=self.stdout)
+            print("*** Out of range", file=self.stdout)
             return
         if arg >= 0:
             self.curindex = arg
@@ -1890,60 +1853,63 @@ except for when using the function decorator.
         self.curframe_locals = self.curframe.f_locals
         self.print_current_stack_entry()
         self.lineno = None
+
     do_f = do_frame
 
-    def do_up(self, arg='1'):
-        arg = '1' if arg == '' else arg
+    def do_up(self, arg="1"):
+        arg = "1" if arg == "" else arg
         try:
             arg = int(arg)
         except (ValueError, TypeError):
-            print(
-                '*** Expected a number, got "{0}"'.format(arg), file=self.stdout)
+            print('*** Expected a number, got "{}"'.format(arg), file=self.stdout)
             return
         if self.curindex - arg < 0:
-            print('*** Oldest frame', file=self.stdout)
+            print("*** Oldest frame", file=self.stdout)
         else:
             self.curindex = self.curindex - arg
             self.curframe = self.stack[self.curindex][0]
             self.curframe_locals = self.curframe.f_locals
             self.print_current_stack_entry()
             self.lineno = None
+
     do_up.__doc__ = pdb.Pdb.do_up.__doc__
     do_u = do_up
 
-    def do_down(self, arg='1'):
-        arg = '1' if arg == '' else arg
+    def do_down(self, arg="1"):
+        arg = "1" if arg == "" else arg
         try:
             arg = int(arg)
         except (ValueError, TypeError):
-            print(
-                '*** Expected a number, got "{0}"'.format(arg), file=self.stdout)
+            print('*** Expected a number, got "{}"'.format(arg), file=self.stdout)
             return
         if self.curindex + arg >= len(self.stack):
-            print('*** Newest frame', file=self.stdout)
+            print("*** Newest frame", file=self.stdout)
         else:
             self.curindex = self.curindex + arg
             self.curframe = self.stack[self.curindex][0]
             self.curframe_locals = self.curframe.f_locals
             self.print_current_stack_entry()
             self.lineno = None
+
     do_down.__doc__ = pdb.Pdb.do_down.__doc__
     do_d = do_down
 
     def do_top(self, arg):
         """Go to top (oldest) frame."""
         if self.curindex == 0:
-            self.error('Oldest frame')
+            self.error("Oldest frame")
             return
         self._select_frame(0)
+
     do_top = do_top
 
     def do_bottom(self, arg):
         """Go to bottom (newest) frame."""
         if self.curindex + 1 == len(self.stack):
-            self.error('Newest frame')
+            self.error("Newest frame")
             return
         self._select_frame(len(self.stack) - 1)
+
     do_bottom = do_bottom
 
     @staticmethod
@@ -1953,16 +1919,17 @@ except for when using the function decorator.
             from shutil import get_terminal_size
         except ImportError:
             try:
-                import termios
                 import fcntl
                 import struct
-                call = fcntl.ioctl(0, termios.TIOCGWINSZ, "\x00"*8)
+                import termios
+
+                call = fcntl.ioctl(0, termios.TIOCGWINSZ, "\x00" * 8)
                 height, width = struct.unpack("hhhh", call)[:2]
             except (SystemExit, KeyboardInterrupt):
                 raise
             except:
-                width = int(os.environ.get('COLUMNS', fallback[0]))
-                height = int(os.environ.get('COLUMNS', fallback[1]))
+                width = int(os.environ.get("COLUMNS", fallback[0]))
+                height = int(os.environ.get("COLUMNS", fallback[1]))
             # Work around above returning width, height = 0, 0 in Emacs
             width = width if width != 0 else fallback[0]
             height = height if height != 0 else fallback[1]
@@ -1980,16 +1947,8 @@ except for when using the function decorator.
         filename = os.path.abspath(frame.f_code.co_filename)
         return filename, lineno
 
-    def _quote_filename(self, filename):
-        try:
-            from shlex import quote
-        except ImportError:
-            from pipes import quote
-
-        return quote(filename)
-
     def _format_editcmd(self, editor, filename, lineno):
-        filename = self._quote_filename(filename)
+        filename = shlex.quote(filename)
 
         if "{filename}" in editor:
             return editor.format(filename=filename, lineno=lineno)
@@ -1999,8 +1958,9 @@ except for when using the function decorator.
             return "%s +%d %s" % (editor, lineno, filename)
 
         # Replace %s with filename, %d with lineno; %% becomes %.
-        return editor.replace("%%", "%").replace("%s", filename).replace(
-            "%d", str(lineno))
+        return (
+            editor.replace("%%", "%").replace("%s", filename).replace("%d", str(lineno))
+        )
 
     def _get_editor_cmd(self, filename, lineno):
         editor = self.config.editor
@@ -2016,12 +1976,14 @@ except for when using the function decorator.
                 if editor is None:
                     editor = which("vi")
             if not editor:
-                raise RuntimeError("Could not detect editor. Configure it or set $EDITOR.")  # noqa: E501
+                raise RuntimeError(
+                    "Could not detect editor. Configure it or set $EDITOR."
+                )  # noqa: E501
         return self._format_editcmd(editor, filename, lineno)
 
     def do_edit(self, arg):
         "Open an editor visiting the current file at the current line"
-        if arg == '':
+        if arg == "":
             filename, lineno = self._get_current_position()
         else:
             filename, lineno = self._get_fnamelineno_for_arg(arg)
@@ -2030,7 +1992,7 @@ except for when using the function decorator.
                 return
         # this case handles code generated with py.code.Source()
         # filename is something like '<0-codegen foo.py:18>'
-        match = re.match(r'.*<\d+-codegen (.*):(\d+)>', filename)
+        match = re.match(r".*<\d+-codegen (.*):(\d+)>", filename)
         if match:
             filename = match.group(1)
             lineno = int(match.group(2))
@@ -2047,23 +2009,27 @@ except for when using the function decorator.
 
     def _get_history_text(self):
         import linecache
+
         line = linecache.getline(self.start_filename, self.start_lineno)
         nspaces = len(line) - len(line.lstrip())
-        indent = ' ' * nspaces
+        indent = " " * nspaces
         history = [indent + s for s in self._get_history()]
-        return '\n'.join(history) + '\n'
+        return "\n".join(history) + "\n"
 
     def _open_stdin_paste(self, stdin_paste, lineno, filename, text):
-        proc = subprocess.Popen([stdin_paste, '+%d' % lineno, filename],
-                                stdin=subprocess.PIPE)
+        proc = subprocess.Popen(
+            [stdin_paste, "+%d" % lineno, filename], stdin=subprocess.PIPE
+        )
         proc.stdin.write(text)
         proc.stdin.close()
 
     def _put(self, text):
         stdin_paste = self.config.stdin_paste
         if stdin_paste is None:
-            print('** Error: the "stdin_paste" option is not configured **',
-                  file=self.stdout)
+            print(
+                '** Error: the "stdin_paste" option is not configured **',
+                file=self.stdout,
+            )
         filename = self.start_filename
         lineno = self.start_lineno
         self._open_stdin_paste(stdin_paste, lineno, filename, text)
@@ -2086,7 +2052,7 @@ except for when using the function decorator.
         """Use set_next() via set_trace() when re-using Pdb instance.
 
         But call set_step() before still for handling of frame_returning."""
-        super(Pdb, self).set_step()
+        super().set_step()
         if hasattr(self, "_set_trace_use_next"):
             del self._set_trace_use_next
             self.set_next(self._via_set_trace_frame)
@@ -2099,7 +2065,7 @@ except for when using the function decorator.
                     self._stopped_for_set_trace = True
                     return True
         if Pdb is not None:
-            return super(Pdb, self).stop_here(frame)
+            return super().stop_here(frame)
 
     def set_trace(self, frame=None):
         """Remember starting frame.
@@ -2121,7 +2087,7 @@ except for when using the function decorator.
         self.start_filename = frame.f_code.co_filename
         self.start_lineno = frame.f_lineno
 
-        return super(Pdb, self).set_trace(frame)
+        return super().set_trace(frame)
 
     def is_skipped_module(self, module_name):
         """Backport for https://bugs.python.org/issue36130.
@@ -2130,7 +2096,7 @@ except for when using the function decorator.
         """
         if module_name is None:
             return False
-        return super(Pdb, self).is_skipped_module(module_name)
+        return super().is_skipped_module(module_name)
 
     def message(self, msg):
         if self.sticky:
@@ -2192,20 +2158,21 @@ except for when using the function decorator.
 
 # simplified interface
 
-if hasattr(pdb, 'Restart'):
+if hasattr(pdb, "Restart"):
     Restart = pdb.Restart
 
-if hasattr(pdb, '_usage'):
+if hasattr(pdb, "_usage"):
     _usage = pdb._usage
 
 # copy some functions from pdb.py, but rebind the global dictionary
-for name in 'run runeval runctx runcall main set_trace'.split():
+for name in "run runeval runctx runcall main set_trace".split():
     func = getattr(pdb, name)
     globals()[name] = rebind_globals(func, globals())
 del name, func
 
 
 # Post-Mortem interface
+
 
 def post_mortem(t=None, Pdb=Pdb):
     # handling the default
@@ -2214,8 +2181,9 @@ def post_mortem(t=None, Pdb=Pdb):
         # being handled, otherwise it returns None
         t = sys.exc_info()[2]
     if t is None:
-        raise ValueError("A valid traceback must be passed if no "
-                         "exception is being handled")
+        raise ValueError(
+            "A valid traceback must be passed if no " "exception is being handled"
+        )
 
     p = Pdb()
     p.reset()
@@ -2229,6 +2197,7 @@ def pm(Pdb=Pdb):
 def cleanup():
     local.GLOBAL_PDB = None
     local._pdbpp_completing = False
+
 
 # pdb++ specific interface
 
@@ -2264,7 +2233,7 @@ disable.set_trace = lambda frame=None, Pdb=Pdb: None
 
 
 def set_tracex():
-    print('PDB!')
+    print("PDB!")
 
 
 set_tracex._dont_inline_ = True
@@ -2276,26 +2245,7 @@ def hideframe(func):
     c = func.__code__
     new_co_consts = c.co_consts + (_HIDE_FRAME,)
 
-    if hasattr(c, "replace"):
-        # Python 3.8.
-        c = c.replace(co_consts=new_co_consts)
-    elif sys.version_info < (3, ):
-        c = types.CodeType(
-            c.co_argcount, c.co_nlocals, c.co_stacksize,
-            c.co_flags, c.co_code,
-            new_co_consts,
-            c.co_names, c.co_varnames, c.co_filename,
-            c.co_name, c.co_firstlineno, c.co_lnotab,
-            c.co_freevars, c.co_cellvars)
-    else:
-        # Python 3 takes an additional arg -- kwonlyargcount.
-        c = types.CodeType(
-            c.co_argcount, c.co_kwonlyargcount, c.co_nlocals, c.co_stacksize,
-            c.co_flags, c.co_code,
-            c.co_consts + (_HIDE_FRAME,),
-            c.co_names, c.co_varnames, c.co_filename,
-            c.co_name, c.co_firstlineno, c.co_lnotab,
-            c.co_freevars, c.co_cellvars)
+    c = c.replace(co_consts=new_co_consts)
 
     func.__code__ = c
     return func
@@ -2318,11 +2268,14 @@ def break_on_setattr(attrname, condition=always, Pdb=Pdb):
                 pdb_.stopframe = frame
                 pdb_.interaction(frame, None)
             old___setattr__(self, attr, value)
+
         cls.__setattr__ = __setattr__
         return cls
+
     return decorator
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import pdbpp
+
     pdbpp.main()

--- a/src/pdbpp_utils/__init__.py
+++ b/src/pdbpp_utils/__init__.py
@@ -1,0 +1,4 @@
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "dev"

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -100,7 +100,7 @@ def readline_param(request):
         try:
             import pyrepl.readline  # noqa: F401
         except ImportError as exc:
-            pytest.skip(msg=f"pyrepl not available: {exc}")
+            pytest.skip(reason=f"pyrepl not available: {exc}")
         finally:
             sys.stdin = old_stdin
         m.setattr("fancycompleter.DefaultConfig.prefer_pyrepl", True)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -43,6 +43,7 @@ def restore_settrace(monkeypatch):
             orig_settrace(_orig_trace)
         else:
             orig_settrace(func)
+
     monkeypatch.setattr("sys.settrace", settrace)
 
     yield
@@ -50,8 +51,9 @@ def restore_settrace(monkeypatch):
     newtrace = sys.gettrace()
     if newtrace is not _orig_trace:
         sys.settrace(_orig_trace)
-        assert newtrace is None, (
-            f"tracing function was not reset! Breakpoints left? ({newtrace})")
+        assert (
+            newtrace is None
+        ), f"tracing function was not reset! Breakpoints left? ({newtrace})"
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -110,6 +112,7 @@ def readline_param(request):
 @pytest.fixture
 def monkeypatch_readline(monkeypatch, readline_param):
     """Patch readline to return given results."""
+
     def inner(line, begidx, endidx):
         if readline_param == "pyrepl":
             readline = "pyrepl.readline"
@@ -188,8 +191,9 @@ def monkeypatch_importerror(monkeypatch):
             return orig_import(name, *args)
 
         with monkeypatch.context() as m:
-            m.setattr('builtins.__import__', import_mock)
+            m.setattr("builtins.__import__", import_mock)
             yield m
+
     return cm
 
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -166,15 +166,14 @@ def patched_completions(monkeypatch):
     return inner
 
 
-@pytest.fixture(params=("color", "nocolor"), scope="session")
-def fancycompleter_color_param(request):
-    m = MonkeyPatch()
-
+@pytest.fixture(params=("color", "nocolor"))
+def fancycompleter_color_param(request, monkeypatch):
     if request.param == "color":
-        m.setattr("fancycompleter.DefaultConfig.use_colors", True)
+        monkeypatch.setattr("fancycompleter.DefaultConfig.use_colors", True)
     else:
-        m.setattr("fancycompleter.DefaultConfig.use_colors", False)
-    return request.param
+        monkeypatch.setattr("fancycompleter.DefaultConfig.use_colors", False)
+
+    yield request.param
 
 
 @pytest.fixture

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -190,10 +190,7 @@ def monkeypatch_importerror(monkeypatch):
             return orig_import(name, *args)
 
         with monkeypatch.context() as m:
-            if sys.version_info >= (3,):
-                m.setattr('builtins.__import__', import_mock)
-            else:
-                m.setattr('__builtin__.__import__', import_mock)
+            m.setattr('builtins.__import__', import_mock)
             yield m
     return cm
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -51,8 +51,7 @@ def restore_settrace(monkeypatch):
     if newtrace is not _orig_trace:
         sys.settrace(_orig_trace)
         assert newtrace is None, (
-            "tracing function was not reset! Breakpoints left? ({})".format(
-                newtrace))
+            f"tracing function was not reset! Breakpoints left? ({newtrace})")
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -99,7 +98,7 @@ def readline_param(request):
         try:
             import pyrepl.readline  # noqa: F401
         except ImportError as exc:
-            pytest.skip(msg="pyrepl not available: {}".format(exc))
+            pytest.skip(msg=f"pyrepl not available: {exc}")
         finally:
             sys.stdin = old_stdin
         m.setattr("fancycompleter.DefaultConfig.prefer_pyrepl", True)
@@ -128,7 +127,7 @@ def monkeypatch_readline(monkeypatch, readline_param):
 @pytest.fixture
 def monkeypatch_pdb_methods(monkeypatch):
     def mock(method, *args, **kwargs):
-        print("=== %s(%s, %s)" % (method, args, kwargs))
+        print(f"=== {method}({args}, {kwargs})")
 
     for mock_method in ("set_trace", "set_continue"):
         monkeypatch.setattr(
@@ -198,4 +197,4 @@ def monkeypatch_importerror(monkeypatch):
 def skip_with_missing_pth_file():
     pth = os.path.join(sysconfig.get_path("purelib"), "pdbpp_hijack_pdb.pth")
     if not os.path.exists(pth):
-        pytest.skip("Missing pth file ({}), editable install?".format(pth))
+        pytest.skip(f"Missing pth file ({pth}), editable install?")

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -43,10 +43,11 @@ def test_integration(testdir, readline_param):
     # fancycompleter.
     child.send(b"b \t")
     if readline_param == "pyrepl":
-        child.expect_exact(b'\x1b[1@b\x1b[1@ \x1b[?25ltest_file.py:'
-                           b'\x1b[?12l\x1b[?25h')
+        child.expect_exact(
+            b"\x1b[1@b\x1b[1@ \x1b[?25ltest_file.py:" b"\x1b[?12l\x1b[?25h"
+        )
     else:
-        child.expect_exact(b'b test_file.py:')
+        child.expect_exact(b"b test_file.py:")
 
     child.sendline("")
     if readline_param == "pyrepl":
@@ -60,9 +61,9 @@ def test_integration(testdir, readline_param):
     child.sendline("c")
     rest = child.read()
     if readline_param == "pyrepl":
-        assert rest == b'\x1b[1@c\x1b[9D\r\n\r\x1b[?1l\x1b>'
+        assert rest == b"\x1b[1@c\x1b[9D\r\n\r\x1b[?1l\x1b>"
     else:
-        assert rest == b'c\r\n'
+        assert rest == b"c\r\n"
 
 
 def test_ipython(testdir):

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -41,22 +41,21 @@ def test_integration(testdir, readline_param):
 
     # Completes breakpoints via pdb, should not contain "\t" from
     # fancycompleter.
-    if sys.version_info >= (3, 3):
-        child.send(b"b \t")
-        if readline_param == "pyrepl":
-            child.expect_exact(b'\x1b[1@b\x1b[1@ \x1b[?25ltest_file.py:'
-                               b'\x1b[?12l\x1b[?25h')
-        else:
-            child.expect_exact(b'b test_file.py:')
+    child.send(b"b \t")
+    if readline_param == "pyrepl":
+        child.expect_exact(b'\x1b[1@b\x1b[1@ \x1b[?25ltest_file.py:'
+                           b'\x1b[?12l\x1b[?25h')
+    else:
+        child.expect_exact(b'b test_file.py:')
 
-        child.sendline("")
-        if readline_param == "pyrepl":
-            child.expect_exact(
-                b"\x1b[23D\r\n\r\x1b[?1l\x1b>*** Bad lineno: \r\n"
-                b"\x1b[?1h\x1b=\x1b[?25l\x1b[1A\r\n(Pdb++) \x1b[?12l\x1b[?25h"
-            )
-        else:
-            child.expect_exact(b"\r\n*** Bad lineno: \r\n(Pdb++) ")
+    child.sendline("")
+    if readline_param == "pyrepl":
+        child.expect_exact(
+            b"\x1b[23D\r\n\r\x1b[?1l\x1b>*** Bad lineno: \r\n"
+            b"\x1b[?1h\x1b=\x1b[?25l\x1b[1A\r\n(Pdb++) \x1b[?12l\x1b[?25h"
+        )
+    else:
+        child.expect_exact(b"\r\n*** Bad lineno: \r\n(Pdb++) ")
 
     child.sendline("c")
     rest = child.read()
@@ -75,9 +74,7 @@ def test_ipython(testdir):
     skip_with_missing_pth_file()
 
     child = testdir.spawn(
-        "{} -m IPython --colors=nocolor --simple-prompt".format(
-            sys.executable,
-        )
+        f"{sys.executable} -m IPython --colors=nocolor --simple-prompt"
     )
     child.sendline("%debug raise ValueError('my_value_error')")
     child.sendline("up")

--- a/testing/test_meta.py
+++ b/testing/test_meta.py
@@ -1,5 +1,3 @@
-import sys
-
 import pdbpp
 import pytest
 
@@ -7,5 +5,4 @@ import pytest
 def test_mod_attributeerror():
     with pytest.raises(AttributeError) as excinfo:
         pdbpp.doesnotexist
-    if sys.version_info >= (3, 5):
-        assert str(excinfo.value) == "module 'pdbpp' has no attribute 'doesnotexist'"
+    assert str(excinfo.value) == "module 'pdbpp' has no attribute 'doesnotexist'"

--- a/testing/test_meta.py
+++ b/testing/test_meta.py
@@ -4,5 +4,5 @@ import pytest
 
 def test_mod_attributeerror():
     with pytest.raises(AttributeError) as excinfo:
-        pdbpp.doesnotexist
+        pdbpp.doesnotexist  # noqa: B018
     assert str(excinfo.value) == "module 'pdbpp' has no attribute 'doesnotexist'"

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2476,7 +2476,7 @@ def test_sticky_dunder_exception_with_highlight():
 <COLORCURLINE>  ->         raises().*
 <COLORLNUM>InnerTestException: <COLORRESET>
 # c
-    """.format(
+    """.format( # noqa: UP032
         filename=RE_THIS_FILE_CANONICAL,
     ))
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -4007,9 +4007,7 @@ def test_frame_cmd_changes_locals():
 """)
 
 
-@pytest.mark.skipif(not hasattr(pdbpp.pdb.Pdb, "_cmdloop"),
-                    reason="_cmdloop is not available")
-def test_sigint_in_interaction_with_new_cmdloop():
+def test_sigint_in_interaction_with_cmdloop():
     def fn():
         def inner():
             raise KeyboardInterrupt()
@@ -4027,32 +4025,6 @@ ENTERING RECURSIVE DEBUGGER
 --KeyboardInterrupt--
 # c
 """)
-
-
-@pytest.mark.skipif(hasattr(pdbpp.pdb.Pdb, "_cmdloop"),
-                    reason="_cmdloop is available")
-def test_sigint_in_interaction_without_new_cmdloop():
-    def fn():
-        def inner():
-            raise KeyboardInterrupt()
-        set_trace()
-
-    with pytest.raises(KeyboardInterrupt):
-        check(fn, """
---Return--
-[NUM] > .*fn()
--> set_trace()
-   5 frames hidden .*
-# debug inner()
-ENTERING RECURSIVE DEBUGGER
-[NUM] > .*
-(#) c
-""")
-
-    # Reset pdb, which did not clean up correctly.
-    # Needed for PyPy (Python 2.7.13[pypy-7.1.0-final]) with coverage and
-    # restoring trace function.
-    pdbpp.local.GLOBAL_PDB.reset()
 
 
 @pytest.mark.skipif(not hasattr(pdbpp.pdb.Pdb, "_previous_sigint_handler"),

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2061,7 +2061,7 @@ class TestListWithChangedSource:
         testdir.monkeypatch.setenv("PDBPP_COLORS", "0")
         testdir.syspathinsert()
 
-    @pytest.mark.xfail(strict=False, reason="Flaky: fails in tox, succeeds when called with pytest - see https://github.com/nedbat/coveragepy/issues/1420")
+    @pytest.mark.xfail(strict=False, reason="Flaky: fails in tox, succeeds when called with pytest - see https://github.com/nedbat/coveragepy/issues/1420") # noqa: E501
     def test_list_with_changed_source(self):
         from myfile import fn
 
@@ -2095,7 +2095,7 @@ class TestListWithChangedSource:
     (Pdb++) c
     """)
 
-    @pytest.mark.xfail(strict=False, reason="Flaky: fails in tox, succeeds when called with pytest - see https://github.com/nedbat/coveragepy/issues/1420")
+    @pytest.mark.xfail(strict=False, reason="Flaky: fails in tox, succeeds when called with pytest - see https://github.com/nedbat/coveragepy/issues/1420") # noqa: E501
     def test_longlist_with_changed_source(self):
         from myfile import fn
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -31,7 +31,7 @@ from .conftest import skip_with_missing_pth_file
 # canonical filename accordingly.
 RE_THIS_FILE = re.escape(__file__)
 THIS_FILE_CANONICAL = __file__
-if sys.platform == 'win32':
+if sys.platform == "win32":
     THIS_FILE_CANONICAL = __file__.lower()
 RE_THIS_FILE_CANONICAL = re.escape(THIS_FILE_CANONICAL)
 RE_THIS_FILE_CANONICAL_QUOTED = re.escape(quote(THIS_FILE_CANONICAL))
@@ -44,19 +44,19 @@ class FakeStdin:
 
     def readline(self):
         try:
-            line = next(self.lines) + '\n'
+            line = next(self.lines) + "\n"
             sys.stdout.write(line)
             return line
         except StopIteration:
-            return ''
+            return ""
 
 
 class ConfigTest(DefaultConfig):
     highlight = False
     use_pygments = False
-    prompt = '# '  # because + has a special meaning in the regexp
-    editor = 'emacs'
-    stdin_paste = 'epaste'
+    prompt = "# "  # because + has a special meaning in the regexp
+    editor = "emacs"
+    stdin_paste = "epaste"
     disable_pytest_capturing = False
     current_line_color = 44
 
@@ -83,7 +83,7 @@ class PdbTest(pdbpp.Pdb):
     def __init__(self, *args, **kwds):
         readrc = kwds.pop("readrc", False)
         nosigint = kwds.pop("nosigint", True)
-        kwds.setdefault('Config', ConfigTest)
+        kwds.setdefault("Config", ConfigTest)
         super().__init__(*args, readrc=readrc, **kwds)
         # Do not install sigint_handler in do_continue by default.
         self.nosigint = nosigint
@@ -122,7 +122,7 @@ def set_trace_via_module(frame=None, cleanup=True, Pdb=PdbTest, **kwds):
             super().set_trace(frame, *args, **kwargs)
 
     newglobals = pdbpp.set_trace.__globals__.copy()
-    newglobals['Pdb'] = PdbForFrame
+    newglobals["Pdb"] = PdbForFrame
     new_set_trace = pdbpp.rebind_globals(pdbpp.set_trace, newglobals)
     new_set_trace(**kwds)
 
@@ -149,13 +149,12 @@ def runpdb(func, input, terminal_size=None):
     # Use __dict__ to avoid class descriptor (staticmethod).
     old_get_terminal_size = pdbpp.Pdb.__dict__["get_terminal_size"]
 
-
     class MyBytesIO(BytesIO):
         """write accepts unicode or bytes"""
 
-        encoding = 'ascii'
+        encoding = "ascii"
 
-        def __init__(self, encoding='utf-8'):
+        def __init__(self, encoding="utf-8"):
             self.encoding = encoding
 
         def write(self, msg):
@@ -164,9 +163,12 @@ def runpdb(func, input, terminal_size=None):
             super().write(msg)
 
         def get_unicode_value(self):
-            return self.getvalue().decode(self.encoding).replace(
-                pdbpp.CLEARSCREEN, "<CLEARSCREEN>\n"
-            ).replace(chr(27), "^[")
+            return (
+                self.getvalue()
+                .decode(self.encoding)
+                .replace(pdbpp.CLEARSCREEN, "<CLEARSCREEN>\n")
+                .replace(chr(27), "^[")
+            )
 
     # Use a predictable terminal size.
     if terminal_size is None:
@@ -201,7 +203,7 @@ def runpdb(func, input, terminal_size=None):
 
 
 def is_prompt(line):
-    prompts = {'# ', '(#) ', '((#)) ', '(((#))) ', '(Pdb) ', '(Pdb++) ', '(com++) '}
+    prompts = {"# ", "(#) ", "((#)) ", "(((#))) ", "(Pdb) ", "(Pdb++) ", "(com++) "}
     for prompt in prompts:
         if line.startswith(prompt):
             return len(prompt)
@@ -218,22 +220,22 @@ def extract_commands(lines):
 
 
 shortcuts = [
-    ('[', '\\['),
-    (']', '\\]'),
-    ('(', '\\('),
-    (')', '\\)'),
-    ('^', '\\^'),
-    (r'\(Pdb++\) ', r'\(Pdb\+\+\) '),
-    (r'\(com++\) ', r'\(com\+\+\) '),
-    ('<COLORCURLINE>', r'\^\[\[44m\^\[\[36;01;44m *[0-9]+\^\[\[00;44m'),
-    ('<COLORNUM>', r'\^\[\[36;01m *[0-9]+\^\[\[00m'),
-    ('<COLORFNAME>', r'\^\[\[33;01m'),
-    ('<COLORLNUM>', r'\^\[\[36;01m'),
-    ('<COLORRESET>', r'\^\[\[00m'),
-    ('<PYGMENTSRESET>', r'\^\[\[39[^m]*m'),
-    ('NUM', ' *[0-9]+'),
+    ("[", "\\["),
+    ("]", "\\]"),
+    ("(", "\\("),
+    (")", "\\)"),
+    ("^", "\\^"),
+    (r"\(Pdb++\) ", r"\(Pdb\+\+\) "),
+    (r"\(com++\) ", r"\(com\+\+\) "),
+    ("<COLORCURLINE>", r"\^\[\[44m\^\[\[36;01;44m *[0-9]+\^\[\[00;44m"),
+    ("<COLORNUM>", r"\^\[\[36;01m *[0-9]+\^\[\[00m"),
+    ("<COLORFNAME>", r"\^\[\[33;01m"),
+    ("<COLORLNUM>", r"\^\[\[36;01m"),
+    ("<COLORRESET>", r"\^\[\[00m"),
+    ("<PYGMENTSRESET>", r"\^\[\[39[^m]*m"),
+    ("NUM", " *[0-9]+"),
     # Optional message with Python 2.7 (e.g. "--Return--"), not using Pdb.message.
-    ('<PY27_MSG>', '\n.*' if sys.version_info < (3,) else ''),
+    ("<PY27_MSG>", "\n.*" if sys.version_info < (3,) else ""),
 ]
 
 
@@ -251,7 +253,7 @@ def run_func(func, expected, terminal_size=None):
     """
     expected = textwrap.dedent(expected).strip().splitlines()
     # Remove comments.
-    expected = [re.split(r'\s+###', line)[0] for line in expected]
+    expected = [re.split(r"\s+###", line)[0] for line in expected]
     commands = extract_commands(expected)
     expected = list(map(cook_regexp, expected))
 
@@ -278,6 +280,7 @@ def count_frames():
 
 class InnerTestException(Exception):
     """Ignored by check()."""
+
     pass
 
 
@@ -302,25 +305,27 @@ def check(func, expected, terminal_size=None):
                 try:
                     ok = re.match(pattern, string)
                 except re.error as exc:
-                    raise ValueError(f"re.match failed for {pattern!r}: {exc!r}")  # noqa: B904
+                    raise ValueError(
+                        f"re.match failed for {pattern!r}: {exc!r}"
+                    )  # noqa: B904
         else:
             ok = False
             if pattern is None:
-                pattern = '<None>'
+                pattern = "<None>"
             if string is None:
-                string = '<None>'
+                string = "<None>"
         # Use "$" to mark end of line with trailing space
-        if re.search(r'\s+$', string):
-            string += '$'
-        if re.search(r'\s+$', pattern):
-            pattern += '$'
+        if re.search(r"\s+$", string):
+            string += "$"
+        if re.search(r"\s+$", pattern):
+            pattern += "$"
         pattern = trans_trn(pattern)
         string = trans_trn(string)
-        print(pattern.ljust(maxlen+1), '| ', string, end='')
+        print(pattern.ljust(maxlen + 1), "| ", string, end="")
         if ok:
             print()
         else:
-            print(pdbpp.Color.set(pdbpp.Color.red, '    <<<<<'))
+            print(pdbpp.Color.set(pdbpp.Color.red, "    <<<<<"))
             all_ok = False
     assert all_ok
 
@@ -383,7 +388,7 @@ def test_config_pygments(monkeypatch):
 
     assert isinstance(
         Pdb(Config=Config)._get_pygments_formatter(),
-        pygments.formatters.TerminalTrueColorFormatter
+        pygments.formatters.TerminalTrueColorFormatter,
     )
 
     source = Pdb(Config=Config).format_source("print(42)")
@@ -407,14 +412,14 @@ def test_config_missing_pygments(use_pygments, monkeypatch_importerror):
 
     pdb_ = PdbForMessage(Config=Config)
 
-    with monkeypatch_importerror(('pygments', 'pygments.formatters')):
+    with monkeypatch_importerror(("pygments", "pygments.formatters")):
         with pytest.raises(ImportError):
             pdb_._get_pygments_formatter()
         assert pdb_._get_source_highlight_function() is False
         assert pdb_.format_source("print(42)") == "print(42)"
 
     if use_pygments is True:
-        assert pdb_.messages == ['Could not import pygments, disabling.']
+        assert pdb_.messages == ["Could not import pygments, disabling."]
     else:
         assert pdb_.messages == []
 
@@ -429,16 +434,18 @@ def test_config_pygments_deprecated_use_terminal256formatter(monkeypatch):
 
     class Config(DefaultConfig):
         use_terminal256formatter = False
+
     assert isinstance(
         Pdb(Config=Config)._get_pygments_formatter(),
-        pygments.formatters.TerminalFormatter
+        pygments.formatters.TerminalFormatter,
     )
 
     class Config(DefaultConfig):
         use_terminal256formatter = True
+
     assert isinstance(
         Pdb(Config=Config)._get_pygments_formatter(),
-        pygments.formatters.Terminal256Formatter
+        pygments.formatters.Terminal256Formatter,
     )
 
 
@@ -448,9 +455,11 @@ def test_runpdb():
         a = 1
         b = 2
         c = 3
-        return a+b+c
+        return a + b + c
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> a = 1
    5 frames hidden .*
@@ -463,7 +472,8 @@ def test_runpdb():
 -> c = 3
    5 frames hidden .*
 # c
-""")
+""",
+    )
 
 
 def test_set_trace_remembers_previous_state():
@@ -477,7 +487,9 @@ def test_set_trace_remembers_previous_state():
         a = 4
         return a
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> a = 2
    5 frames hidden .*
@@ -493,7 +505,8 @@ a: 1 --> 2
    5 frames hidden .*
 a: 2 --> 3
 # c
-""")
+""",
+    )
 
 
 def test_set_trace_remembers_previous_state_via_module():
@@ -507,7 +520,9 @@ def test_set_trace_remembers_previous_state_via_module():
         a = 4
         return a
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> a = 2
    5 frames hidden .*
@@ -523,7 +538,8 @@ a: 1 --> 2
    5 frames hidden .*
 a: 2 --> 3
 # c
-""")
+""",
+    )
 
 
 class TestPdbMeta:
@@ -531,7 +547,6 @@ class TestPdbMeta:
         assert pdbpp.PdbMeta.called_for_set_trace(sys._getframe()) is False
 
     def test_called_for_set_trace_staticmethod(self):
-
         class Foo:
             @staticmethod
             def set_trace():
@@ -542,7 +557,6 @@ class TestPdbMeta:
         assert Foo.set_trace() is True
 
     def test_called_for_set_trace_method(self):
-
         class Foo:
             def set_trace(self):
                 frame = sys._getframe()
@@ -560,11 +574,11 @@ class TestPdbMeta:
         assert set_trace() is True
 
     def test_called_for_set_trace_via_other_func(self):
-
         def somefunc():
             def meta():
                 frame = sys._getframe()
                 assert pdbpp.PdbMeta.called_for_set_trace(frame) is False
+
             meta()
             return True
 
@@ -578,6 +592,7 @@ def test_forget_with_new_pdb():
     e.g. when pdbpp was used before pytest's debugging plugin was setup, which
     then later uses a custom Pdb wrapper.
     """
+
     def fn():
         set_trace()
 
@@ -589,7 +604,9 @@ def test_forget_with_new_pdb():
         new_pdb = NewPdb()
         new_pdb.set_trace()
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> class NewPdb(PdbTest, pdbpp.Pdb):
    5 frames hidden .*
@@ -612,7 +629,8 @@ NUM .*
 NUM .*
 NUM .*
 # c
-""")
+""",
+    )
 
 
 def test_global_pdb_with_classmethod():
@@ -631,7 +649,9 @@ def test_global_pdb_with_classmethod():
         new_pdb = NewPdb()
         new_pdb.set_trace()
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> assert isinstance(pdbpp.local.GLOBAL_PDB, PdbTest)
    5 frames hidden .*
@@ -641,7 +661,8 @@ new_set_trace
 -> assert pdbpp.local.GLOBAL_PDB is self
    5 frames hidden .*
 # c
-""")
+""",
+    )
 
 
 def test_global_pdb_via_new_class_in_init_method():
@@ -653,7 +674,6 @@ def test_global_pdb_via_new_class_in_init_method():
         class PdbLikePytest:
             @classmethod
             def init_pdb(cls):
-
                 class NewPdb(PdbTest, pdbpp.Pdb):
                     def set_trace(self, frame):
                         print("new_set_trace")
@@ -675,7 +695,9 @@ def test_global_pdb_via_new_class_in_init_method():
         third = pdbpp.local.GLOBAL_PDB
         assert third == second
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> first = pdbpp.local.GLOBAL_PDB
    5 frames hidden .*
@@ -690,7 +712,8 @@ new_set_trace
 -> third = pdbpp.local.GLOBAL_PDB
    5 frames hidden .*
 # c
-""")
+""",
+    )
 
 
 def test_global_pdb_via_existing_class_in_init_method():
@@ -723,7 +746,9 @@ def test_global_pdb_via_existing_class_in_init_method():
         third = pdbpp.local.GLOBAL_PDB
         assert third == second
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> first = pdbpp.local.GLOBAL_PDB
    5 frames hidden .*
@@ -738,7 +763,8 @@ new_set_trace
 -> third = pdbpp.local.GLOBAL_PDB
    5 frames hidden .*
 # c
-""")
+""",
+    )
 
 
 def test_global_pdb_can_be_skipped():
@@ -762,7 +788,9 @@ def test_global_pdb_can_be_skipped():
         set_trace(cleanup=False)
         assert pdbpp.local.GLOBAL_PDB is not new_pdb
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> first = pdbpp.local.GLOBAL_PDB
    5 frames hidden .*
@@ -778,11 +806,13 @@ new_set_trace
 -> assert pdbpp.local.GLOBAL_PDB is not new_pdb
    5 frames hidden .*
 # c
-""")
+""",
+    )
 
 
 def test_global_pdb_can_be_skipped_unit(monkeypatch_pdb_methods):
     """Same as test_global_pdb_can_be_skipped, but with mocked Pdb methods."""
+
     def fn():
         set_trace()
         first = pdbpp.local.GLOBAL_PDB
@@ -803,12 +833,15 @@ def test_global_pdb_can_be_skipped_unit(monkeypatch_pdb_methods):
         set_trace(cleanup=False)
         assert pdbpp.local.GLOBAL_PDB is not new_pdb
 
-    check(fn, """
+    check(
+        fn,
+        """
 === set_trace
 new_set_trace
 === set_trace
 === set_trace
-""")
+""",
+    )
 
 
 def test_global_pdb_can_be_skipped_but_set():
@@ -832,7 +865,9 @@ def test_global_pdb_can_be_skipped_but_set():
         set_trace(cleanup=False)
         assert pdbpp.local.GLOBAL_PDB is new_pdb
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> first = pdbpp.local.GLOBAL_PDB
    5 frames hidden .*
@@ -849,7 +884,8 @@ new_set_trace
 -> assert pdbpp.local.GLOBAL_PDB is new_pdb
    5 frames hidden .*
 # c
-""")
+""",
+    )
 
 
 def test_global_pdb_can_be_skipped_but_set_unit(monkeypatch_pdb_methods):
@@ -873,13 +909,16 @@ def test_global_pdb_can_be_skipped_but_set_unit(monkeypatch_pdb_methods):
         set_trace(cleanup=False)
         assert pdbpp.local.GLOBAL_PDB is new_pdb
 
-    check(fn, """
+    check(
+        fn,
+        """
 === set_trace
 new_set_trace
 === set_trace
 new_set_trace
 === set_trace
-""")
+""",
+    )
 
 
 def test_global_pdb_only_reused_for_same_class(monkeypatch_pdb_methods):
@@ -910,7 +949,9 @@ def test_global_pdb_only_reused_for_same_class(monkeypatch_pdb_methods):
         new_pdb.set_trace()
         assert pdbpp.local.GLOBAL_PDB is not new_pdb
 
-    check(fn, """
+    check(
+        fn,
+        """
 new_set_trace
 === set_trace
 === set_trace
@@ -920,7 +961,8 @@ new_set_trace
 === set_trace
 new_set_trace
 === set_trace
-""")
+""",
+    )
 
 
 def test_global_pdb_not_reused_with_different_home(
@@ -937,11 +979,14 @@ def test_global_pdb_not_reused_with_different_home(
         set_trace(cleanup=False)
         assert first is not pdbpp.local.GLOBAL_PDB
 
-    check(fn, """
+    check(
+        fn,
+        """
 === set_trace
 === set_trace
 === set_trace
-""")
+""",
+    )
 
 
 def test_single_question_mark():
@@ -952,13 +997,16 @@ def test_single_question_mark():
         def f2(x, y):
             """Return product of x and y"""
             return x * y
+
         set_trace()
         a = 1
         b = 2
         c = 3
-        return a+b+c
+        return a + b + c
 
-    check(fn, fr"""
+    check(
+        fn,
+        rf"""
 [NUM] > .*fn()
 -> a = 1
    5 frames hidden .*
@@ -978,11 +1026,13 @@ def test_single_question_mark():
 # doesnotexist?
 \*\*\* NameError.*
 # c
-    """)
+    """,
+    )
 
 
 def test_double_question_mark():
     """Test do_inspect_with_source."""
+
     def fn():
         class TestStr(str):
             __doc__ = "shortened"
@@ -997,9 +1047,11 @@ def test_double_question_mark():
         a = 1
         b = 2
         c = 3
-        return a+b+c
+        return a + b + c
 
-    check(fn, fr"""
+    check(
+        fn,
+        rf"""
 [NUM] > .*fn()
 -> a = 1
    5 frames hidden .*
@@ -1024,7 +1076,8 @@ def test_double_question_mark():
 ^[[31;01mDocstring:^[[00m      shortened
 ^[[31;01mSource:^[[00m         -
 # c
-    """)
+    """,
+    )
 
 
 def test_question_mark_unit(capsys, LineMatcher):
@@ -1037,15 +1090,17 @@ def test_question_mark_unit(capsys, LineMatcher):
     _pdb.do_inspect("foo")
 
     out, err = capsys.readouterr()
-    LineMatcher(out.splitlines()).fnmatch_lines([
-        "\x1b[31;01mString Form:\x1b[00m    {12: 34}"
-    ])
+    LineMatcher(out.splitlines()).fnmatch_lines(
+        ["\x1b[31;01mString Form:\x1b[00m    {12: 34}"]
+    )
 
     _pdb.do_inspect("doesnotexist")
     out, err = capsys.readouterr()
-    LineMatcher(out.splitlines()).re_match_lines([
-        r"^\*\*\* NameError:",
-    ])
+    LineMatcher(out.splitlines()).re_match_lines(
+        [
+            r"^\*\*\* NameError:",
+        ]
+    )
 
     # Source for function, indented docstring.
     def foo():
@@ -1053,29 +1108,35 @@ def test_question_mark_unit(capsys, LineMatcher):
 
         3rd line."""
         raise NotImplementedError()
+
     _pdb.setup(sys._getframe(), None)
     _pdb.do_inspect_with_source("foo")
     out, err = capsys.readouterr()
-    LineMatcher(out.splitlines()).re_match_lines([
-        r"\x1b\[31;01mDocstring:\x1b\[00m      doc_for_foo",
-        r"",
-        r"                3rd line\.",
-        r"\x1b\[31;01mSource:\x1b\[00m        ",
-        r" ?\d+         def foo\(\):",
-        r" ?\d+             raise NotImplementedError\(\)",
-    ])
+    LineMatcher(out.splitlines()).re_match_lines(
+        [
+            r"\x1b\[31;01mDocstring:\x1b\[00m      doc_for_foo",
+            r"",
+            r"                3rd line\.",
+            r"\x1b\[31;01mSource:\x1b\[00m        ",
+            r" ?\d+         def foo\(\):",
+            r" ?\d+             raise NotImplementedError\(\)",
+        ]
+    )
 
     # Missing source
     _pdb.do_inspect_with_source("str.strip")
     out, err = capsys.readouterr()
-    LineMatcher(out.splitlines()).fnmatch_lines([
-        "\x1b[31;01mSource:\x1b[00m         -",
-    ])
+    LineMatcher(out.splitlines()).fnmatch_lines(
+        [
+            "\x1b[31;01mSource:\x1b[00m         -",
+        ]
+    )
 
 
 def test_single_question_mark_with_existing_command(monkeypatch):
     def mocked_inspect(self, arg):
         print("mocked_inspect: %r" % arg)
+
     monkeypatch.setattr(PdbTest, "do_inspect", mocked_inspect)
 
     def fn():
@@ -1083,10 +1144,13 @@ def test_single_question_mark_with_existing_command(monkeypatch):
 
         class MyClass:
             pass
+
         a = MyClass()  # noqa: F841
         set_trace()
 
-    check(fn, """
+    check(
+        fn,
+        """
 --Return--
 [NUM] > .*fn()->None
 -> set_trace()
@@ -1106,7 +1170,8 @@ do_shell_called: a?
 a(rgs)
 .*
 # c
-""")
+""",
+    )
 
 
 def test_up_local_vars():
@@ -1118,7 +1183,9 @@ def test_up_local_vars():
         xx = 42  # noqa: F841
         nested()
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*nested()
 -> return
    5 frames hidden .*
@@ -1128,7 +1195,8 @@ def test_up_local_vars():
 # xx
 42
 # c
-""")
+""",
+    )
 
 
 def test_frame():
@@ -1142,7 +1210,9 @@ def test_frame():
         set_trace()
         return
 
-    check(a, f"""
+    check(
+        a,
+        f"""
 [NUM] > .*c()
 -> return
    5 frames hidden .*
@@ -1159,18 +1229,22 @@ def test_frame():
 [{len(traceback.extract_stack())}] > .*c()
 -> return
 # c
-    """)
+    """,
+    )
 
 
 def test_fstrings(monkeypatch):
     def mocked_inspect(self, arg):
         print("mocked_inspect: %r" % arg)
+
     monkeypatch.setattr(PdbTest, "do_inspect", mocked_inspect)
 
     def f():
         set_trace()
 
-    check(f, """
+    check(
+        f,
+        """
 --Return--
 [NUM] > .*
 -> set_trace()
@@ -1180,7 +1254,8 @@ def test_fstrings(monkeypatch):
 # f"foo"?
 mocked_inspect: 'f"foo"'
 # c
-""")
+""",
+    )
 
 
 def test_prefixed_strings(monkeypatch):
@@ -1212,7 +1287,10 @@ mocked_inspect: 'r"foo"'
 # u"foo"?
 mocked_inspect: 'u"foo"'
 # c
-""".format(bytestring=b"string", unicodestring="string"))
+""".format(
+            bytestring=b"string", unicodestring="string"
+        ),
+    )
 
 
 def test_up_down_arg():
@@ -1226,7 +1304,9 @@ def test_up_down_arg():
         set_trace()
         return
 
-    check(a, """
+    check(
+        a,
+        """
 [NUM] > .*c()
 -> return
    5 frames hidden .*
@@ -1237,7 +1317,8 @@ def test_up_down_arg():
 [NUM] > .*a()
 -> b()
 # c
-""")
+""",
+    )
 
 
 def test_up_down_sticky():
@@ -1248,7 +1329,9 @@ def test_up_down_sticky():
         set_trace()
         return
 
-    check(a, """
+    check(
+        a,
+        """
 [NUM] > .*b()
 -> return
    5 frames hidden .*
@@ -1266,7 +1349,8 @@ NUM  ->         return
 NUM         def a()
 NUM  ->         b()
 # c
-""")
+""",
+    )
 
 
 def test_top_bottom():
@@ -1281,7 +1365,8 @@ def test_top_bottom():
         return
 
     check(
-        a, f"""
+        a,
+        f"""
 [NUM] > .*c()
 -> return
    5 frames hidden .*
@@ -1292,13 +1377,14 @@ def test_top_bottom():
 [{len(traceback.extract_stack())}] > .*c()
 -> return
 # c
-""")
+""",
+    )
 
 
 def test_top_bottom_frame_post_mortem():
     def fn():
         def throws():
-            0 / 0 # noqa: B018
+            0 / 0  # noqa: B018
 
         def f():
             throws()
@@ -1307,7 +1393,10 @@ def test_top_bottom_frame_post_mortem():
             f()
         except:
             pdbpp.post_mortem(Pdb=PdbTest)
-    check(fn, r"""
+
+    check(
+        fn,
+        r"""
 [2] > .*throws()
 -> 0 / 0
 # top
@@ -1329,7 +1418,8 @@ def test_top_bottom_frame_post_mortem():
 # frame -3
 \*\*\* Out of range
 # c
-""")
+""",
+    )
 
 
 def test_parseline():
@@ -1338,7 +1428,9 @@ def test_parseline():
         set_trace()
         return c
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> return c
    5 frames hidden .*
@@ -1354,23 +1446,28 @@ do_shell_called: 'c'
 # r
 6
 # !!c
-""")
+""",
+    )
 
 
 def test_parseline_with_rc_commands(tmpdir):
     """Test that parseline handles execution of rc lines during setup."""
     with tmpdir.as_cwd():
         with open(".pdbrc", "w") as f:
-            f.writelines([
-                "p 'readrc'\n",
-                "alias myalias print(%1)\n",
-            ])
+            f.writelines(
+                [
+                    "p 'readrc'\n",
+                    "alias myalias print(%1)\n",
+                ]
+            )
 
         def fn():
             alias = "trigger"  # noqa: F841
             set_trace(readrc=True)
 
-        check(fn, """
+        check(
+            fn,
+            """
 --Return--
 'readrc'
 [NUM] > .*fn()->None
@@ -1383,7 +1480,8 @@ myalias = print(%1)
 # myalias 42
 42
 # c
-""")
+""",
+        )
 
 
 def test_parseline_with_existing_command():
@@ -1397,7 +1495,9 @@ def test_parseline_with_existing_command():
         set_trace()
         return c
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> return c
    5 frames hidden .*
@@ -1424,7 +1524,8 @@ True
 # r.text
 'r.text'
 # cont
-""")
+""",
+    )
 
 
 def test_parseline_remembers_smart_command_escape():
@@ -1435,7 +1536,9 @@ def test_parseline_remembers_smart_command_escape():
         n = 44
         return n
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> n = 43
    5 frames hidden .*
@@ -1452,7 +1555,8 @@ def test_parseline_remembers_smart_command_escape():
 # n
 44
 # c
-""")  # noqa: W291
+""",
+    )  # noqa: W291
 
 
 def test_args_name():
@@ -1461,14 +1565,17 @@ def test_args_name():
         set_trace()
         return args
 
-    check(fn, """
+    check(
+        fn,
+        """
 [NUM] > .*fn()
 -> return args
    5 frames hidden .*
 # args
 42
 # c
-""")
+""",
+    )
 
 
 def lineno():
@@ -1542,7 +1649,6 @@ def test_help():
         ("where", "Print a stack trace"),
         ("hidden_frames", 'Some frames might be marked as "hidden"'),
         ("exec", r"Execute the \(one-line\) statement"),
-
         ("hf_list", r"\*\*\* No help"),
         ("paste", r"\*\*\* No help"),
         ("put", r"\*\*\* No help"),
@@ -1577,7 +1683,9 @@ def test_shortlist():
         set_trace(Config=ConfigTest)
         return a
 
-    check(fn, f"""
+    check(
+        fn,
+        f"""
 [NUM] > .*fn()
 -> return a
    5 frames hidden .*
@@ -1587,7 +1695,8 @@ NUM +\t        a = 1
 NUM +\t        set_trace(Config=ConfigTest)
 NUM +->	        return a
 # c
-""")
+""",
+    )
 
 
 def test_shortlist_with_pygments_and_EOF():
@@ -1596,14 +1705,17 @@ def test_shortlist_with_pygments_and_EOF():
         set_trace(Config=ConfigWithPygments)
         return a
 
-    check(fn, f"""
+    check(
+        fn,
+        f"""
 [NUM] > .*fn()
 -> ^[[38;5;28;01mreturn^[[39;00m a
    5 frames hidden .*
 # l {100000}, 3
 [EOF]
 # c
-""")
+""",
+    )
 
 
 def test_shortlist_with_highlight_and_EOF():
@@ -1612,7 +1724,9 @@ def test_shortlist_with_highlight_and_EOF():
         set_trace(Config=ConfigWithHighlight)
         return a
 
-    check(fn, f"""
+    check(
+        fn,
+        f"""
 [NUM] > .*fn()
 -> return a
    5 frames hidden .*
@@ -1621,6 +1735,7 @@ def test_shortlist_with_highlight_and_EOF():
 # c
 """,
     )
+
 
 # a lot of the following tests are sensitive to formatting,
 # so let's avoid formatting to avoid headaches
@@ -3397,7 +3512,6 @@ def test_hidden_pytest_frames():
 # c
     """)
 
-
 def test_hidden_pytest_frames_f_local_nondict():
     class M:
         values = []
@@ -4354,6 +4468,7 @@ def test_completion_uses_tab_from_fancycompleter(monkeypatch_readline):
 True
 # c
 """)
+
 
 
 def test_complete_removes_duplicates_with_coloring(

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2061,6 +2061,7 @@ class TestListWithChangedSource:
         testdir.monkeypatch.setenv("PDBPP_COLORS", "0")
         testdir.syspathinsert()
 
+    @pytest.mark.xfail(strict=False, reason="Flaky: fails in tox, succeeds when called with pytest - see https://github.com/nedbat/coveragepy/issues/1420")
     def test_list_with_changed_source(self):
         from myfile import fn
 
@@ -2094,6 +2095,7 @@ class TestListWithChangedSource:
     (Pdb++) c
     """)
 
+    @pytest.mark.xfail(strict=False, reason="Flaky: fails in tox, succeeds when called with pytest - see https://github.com/nedbat/coveragepy/issues/1420")
     def test_longlist_with_changed_source(self):
         from myfile import fn
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1164,8 +1164,10 @@ do_shell_called: a?
 # !a?
 \\*\\*\\* SyntaxError:
 # help a
-a(rgs)
-.*
+.*a(rgs)
+"""
+        + ("\n.*" if sys.version_info >= (3, 12) else "")
+        + """
 # c
 """,
     )

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -234,8 +234,6 @@ shortcuts = [
     ("<COLORRESET>", r"\^\[\[00m"),
     ("<PYGMENTSRESET>", r"\^\[\[39[^m]*m"),
     ("NUM", " *[0-9]+"),
-    # Optional message with Python 2.7 (e.g. "--Return--"), not using Pdb.message.
-    ("<PY27_MSG>", "\n.*" if sys.version_info < (3,) else ""),
 ]
 
 
@@ -255,9 +253,8 @@ def run_func(func, expected, terminal_size=None):
     # Remove comments.
     expected = [re.split(r"\s+###", line)[0] for line in expected]
     commands = extract_commands(expected)
-    expected = list(map(cook_regexp, expected))
+    expected = map(cook_regexp, expected)
 
-    # Explode newlines from pattern replacements (PY27_MSG).
     flattened = []
     for line in expected:
         if line == "":
@@ -2269,7 +2266,7 @@ NUM             print(a)
 NUM             set_trace(cleanup=False)
 NUM  ->         return a
 # n
-<CLEARSCREEN><PY27_MSG>
+<CLEARSCREEN>
 [NUM] > .*fn()->1, 5 frames hidden
 
 NUM         def fn():
@@ -2305,7 +2302,7 @@ NUM                 set_trace(cleanup=cleanup)
 NUM  ->             print(cleanup)
 # n
 <CLEARSCREEN>
-True<PY27_MSG>
+True
 [NUM] > .*inner()->None, 5 frames hidden
 
 NUM             def inner(cleanup):
@@ -2320,7 +2317,7 @@ NUM                 set_trace(cleanup=cleanup)
 NUM  ->             print(cleanup)
 # n
 <CLEARSCREEN>
-False<PY27_MSG>
+False
 [NUM] > .*inner()->None, 5 frames hidden
 
 NUM             def inner(cleanup):
@@ -2540,7 +2537,7 @@ NUM                 return 40 \\+ 2
 # retval
 \\*\\*\\* Not yet returned!
 # r
-<CLEARSCREEN><PY27_MSG>
+<CLEARSCREEN>
 [NUM] > {RE_THIS_FILE_CANONICAL}(NUM)returns()->42, 5 frames hidden
 
 NUM             def returns():
@@ -2582,7 +2579,7 @@ NUM                 raise InnerTestException()
 NUM             def throws():
 NUM  ->             raise InnerTestException()
 # n
-<CLEARSCREEN><PY27_MSG>
+<CLEARSCREEN>
 [NUM] > .*throws(), 5 frames hidden
 
 NUM             def throws():
@@ -2623,7 +2620,7 @@ NUM  ->         __exception__ = "foo"  # noqa: F841
 NUM             set_trace(cleanup=False)
 ValueError: very long excmsg\\nvery long excmsg\\nvery long e…
 # c
-<PY27_MSG>[NUM] > .*fn()->None, 5 frames hidden
+[NUM] > .*fn()->None, 5 frames hidden
 
 NUM         def fn():
 NUM             outer()

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1531,7 +1531,6 @@ def test_help():
         ("step", "Execute the current line, stop at the first possible occasion"),
         ("sticky", "Toggle sticky mode"),
         ("tbreak", "arguments as break"),
-        ("track", "track expression"),
         ("u", "Move the current frame .* up"),
         ("unalias", "specified alias."),
         ("undisplay", "Remove expression from the display list"),
@@ -3658,21 +3657,6 @@ False
 # c
 """)
 
-
-def test_track_with_no_args():
-    pytest.importorskip('rpython.translator.tool.reftracker')
-
-    def fn():
-        set_trace()
-        return 42
-
-    check(fn, """
-[NUM] > .*fn()
--> return 42
-# track
-... SyntaxError:
-# c
-""")
 
 
 def test_utf8():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -3419,13 +3419,17 @@ def test_hidden_pytest_frames_f_local_nondict():
         exec("print(1)", {}, m)
         assert m.values == [('__return__', None)]
 
-    check(fn, r"""
+    # 3.11 shows the exec frame as <string>(0), while 3.8 shows <string>(1)
+    # See https://docs.python.org/3/whatsnew/3.11.html#inspect
+    line_no = 0 if sys.version_info >= (3, 11) else 1
+
+    check(fn, fr"""
 [NUM] > .*fn()
--> exec("print(1)", {}, m)
+-> exec("print(1)", {{}}, m)
    5 frames hidden (try 'help hidden_frames')
 # s
 --Call--
-[NUM] > <string>(1)<module>()
+[NUM] > <string>({line_no})<module>()
    5 frames hidden (try 'help hidden_frames')
 # n
 [NUM] > <string>(1)<module>()

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -14,6 +14,7 @@ import traceback
 from io import BytesIO
 
 import pdbpp
+import pygments
 import pytest
 from pdbpp import DefaultConfig, Pdb, StringIO
 
@@ -28,6 +29,12 @@ try:
     from itertools import zip_longest
 except ImportError:
     from itertools import izip_longest as zip_longest
+
+# ref: https://github.com/pygments/pygments/commit/147b22fa
+PYGMENTS_VERSION_TUPLE = tuple(int(x) for x in pygments.__version__.split("."))
+PYGMENTS_WHITESPACE_PREFIX = (
+    "^[[38;5;250m        ^[[39m" if PYGMENTS_VERSION_TUPLE > (2, 14) else "        "
+)
 
 
 # Windows support
@@ -1756,7 +1763,7 @@ def test_truncated_source_with_pygments():
 # l {line_num}, 5
 NUM +\t$
 NUM +\t    ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-NUM +\t^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
+NUM +\t{pygments_prefix}^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
 NUM +\t        a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 NUM +\t        set_trace(Config^[[38;5;241m=^[[39mConfigWithPygments)
 NUM +\t$
@@ -1765,13 +1772,16 @@ NUM +\t$
 [NUM] > .*fn(), 5 frames hidden
 
 NUM +       ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-NUM +    ^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines^[[39.*m
+NUM +    {pygments_prefix}^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines^[[39.*m
 NUM +           a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 NUM +           set_trace(Config^[[38;5;241m=^[[39mConfigWithPygments)
 NUM +$
 NUM +->         ^[[38;5;28;01mreturn^[[39;00m a
 # c
-""".format(line_num=fn.__code__.co_firstlineno - 1))  # noqa: E501
+""".format(  # noqa: E501
+        line_num=fn.__code__.co_firstlineno - 1,
+        pygments_prefix=PYGMENTS_WHITESPACE_PREFIX,
+    ))
 
 
 def test_truncated_source_with_pygments_and_highlight():
@@ -1790,7 +1800,7 @@ def test_truncated_source_with_pygments_and_highlight():
 # l {line_num}, 5
 <COLORNUM> +\t$
 <COLORNUM> +\t    ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-<COLORNUM> +\t^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
+<COLORNUM> +\t{pygments_prefix}^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
 <COLORNUM> +\t        a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 <COLORNUM> +\t        set_trace(Config^[[38;5;241m=^[[39mConfigWithPygmentsAndHighlight)
 <COLORNUM> +\t$
@@ -1799,13 +1809,16 @@ def test_truncated_source_with_pygments_and_highlight():
 [NUM] > .*fn(), 5 frames hidden
 
 <COLORNUM> +       ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-<COLORNUM> +   ^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines<PYGMENTSRESET>
+<COLORNUM> +    {pygments_prefix}^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines<PYGMENTSRESET>
 <COLORNUM> +           a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 <COLORNUM> +           set_trace(Config^[[38;5;241m=^[[39mConfigWithPygmentsAndHighlight)
 <COLORNUM> +$
 <COLORCURLINE> +->         ^[[38;5;28;01;44mreturn<PYGMENTSRESET> a                                                       ^[[00m
 # c
-""".format(line_num=fn.__code__.co_firstlineno - 1))  # noqa: E501
+""".format(  # noqa: E501
+        line_num=fn.__code__.co_firstlineno - 1,
+        pygments_prefix=PYGMENTS_WHITESPACE_PREFIX,
+    ))
 
 
 def test_shortlist_with_highlight():

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1756,7 +1756,7 @@ def test_truncated_source_with_pygments():
 # l {line_num}, 5
 NUM +\t$
 NUM +\t    ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-NUM +\t        ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
+NUM +\t^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
 NUM +\t        a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 NUM +\t        set_trace(Config^[[38;5;241m=^[[39mConfigWithPygments)
 NUM +\t$
@@ -1765,7 +1765,7 @@ NUM +\t$
 [NUM] > .*fn(), 5 frames hidden
 
 NUM +       ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-NUM +           ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines^[[39.*m
+NUM +    ^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines^[[39.*m
 NUM +           a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 NUM +           set_trace(Config^[[38;5;241m=^[[39mConfigWithPygments)
 NUM +$
@@ -1790,7 +1790,7 @@ def test_truncated_source_with_pygments_and_highlight():
 # l {line_num}, 5
 <COLORNUM> +\t$
 <COLORNUM> +\t    ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-<COLORNUM> +\t        ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
+<COLORNUM> +\t^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
 <COLORNUM> +\t        a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 <COLORNUM> +\t        set_trace(Config^[[38;5;241m=^[[39mConfigWithPygmentsAndHighlight)
 <COLORNUM> +\t$
@@ -1799,7 +1799,7 @@ def test_truncated_source_with_pygments_and_highlight():
 [NUM] > .*fn(), 5 frames hidden
 
 <COLORNUM> +       ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-<COLORNUM> +           ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines<PYGMENTSRESET>
+<COLORNUM> +   ^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines<PYGMENTSRESET>
 <COLORNUM> +           a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 <COLORNUM> +           set_trace(Config^[[38;5;241m=^[[39mConfigWithPygmentsAndHighlight)
 <COLORNUM> +$

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1620,7 +1620,12 @@ def test_shortlist_with_highlight_and_EOF():
 # l {100000}, 3
 [EOF]
 # c
-""")
+""",
+    )
+
+# a lot of the following tests are sensitive to formatting,
+# so let's avoid formatting to avoid headaches
+# fmt: off
 
 
 @pytest.mark.parametrize('config', [ConfigWithPygments, ConfigWithPygmentsNone])
@@ -1710,7 +1715,7 @@ def test_truncated_source_with_pygments():
 # l {line_num}, 5
 NUM +\t$
 NUM +\t    ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-NUM +\t        ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
+NUM +\t^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
 NUM +\t        a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 NUM +\t        set_trace(Config^[[38;5;241m=^[[39mConfigWithPygments)
 NUM +\t$
@@ -1719,7 +1724,7 @@ NUM +\t$
 [NUM] > .*fn(), 5 frames hidden
 
 NUM +       ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-NUM +           ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines^[[39.*m
+NUM +^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines^[[39.*m
 NUM +           a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 NUM +           set_trace(Config^[[38;5;241m=^[[39mConfigWithPygments)
 NUM +$
@@ -1744,7 +1749,7 @@ def test_truncated_source_with_pygments_and_highlight():
 # l {line_num}, 5
 <COLORNUM> +\t$
 <COLORNUM> +\t    ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-<COLORNUM> +\t        ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
+<COLORNUM> +\t^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines, which is 80\"\"\"^[[39.*m
 <COLORNUM> +\t        a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 <COLORNUM> +\t        set_trace(Config^[[38;5;241m=^[[39mConfigWithPygmentsAndHighlight)
 <COLORNUM> +\t$
@@ -1753,7 +1758,7 @@ def test_truncated_source_with_pygments_and_highlight():
 [NUM] > .*fn(), 5 frames hidden
 
 <COLORNUM> +       ^[[38;5;28;01mdef^[[39;00m ^[[38;5;21mfn^[[39m():
-<COLORNUM> +           ^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines<PYGMENTSRESET>
+<COLORNUM> +^[[38;5;250m        ^[[39m^[[38;5;124.*m\"\"\"some docstring longer than maxlength for truncate_long_lines<PYGMENTSRESET>
 <COLORNUM> +           a ^[[38;5;241m=^[[39m ^[[38;5;241m1^[[39m
 <COLORNUM> +           set_trace(Config^[[38;5;241m=^[[39mConfigWithPygmentsAndHighlight)
 <COLORNUM> +$

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -1090,7 +1090,7 @@ def test_question_mark_unit(capsys, LineMatcher):
     ])
 
     # Source for function, indented docstring.
-    def foo():
+    def foo():  # noqa: F811
         """doc_for_foo
 
         3rd line."""
@@ -4542,7 +4542,7 @@ def test_complete_removes_duplicates_with_coloring(
             if readline_param == "pyrepl":
                 assert pdbpp.local.GLOBAL_PDB.fancycompleter.config.use_colors is True
                 comps = get_completions("helpvar.")
-                assert type(helpvar.denominator) == int
+                assert type(helpvar.denominator) is int
                 assert any(
                     re.match(r"\x1b\[\d\d\d;00m\x1b\[33;01mdenominator\x1b\[00m", x)
                     for x in comps

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -14,7 +14,6 @@ import traceback
 from io import BytesIO
 
 import pdbpp
-import py
 import pytest
 from pdbpp import DefaultConfig, Pdb, StringIO
 
@@ -2960,29 +2959,6 @@ AssertionError.*
     ))
 
 
-def test_py_code_source():  # noqa: F821
-    src = py.code.Source("""
-    def fn():
-        x = 42
-        set_trace()
-        return x
-    """)
-
-    exec(src.compile(), globals())
-    check(fn,  # noqa: F821
-          """
-[NUM] > .*fn()
--> return x
-   5 frames hidden .*
-# ll
-NUM     def fn():
-NUM         x = 42
-NUM         set_trace()
-NUM  ->     return x
-# c
-""")
-
-
 def test_source():
     def bar():
         return 42
@@ -3162,28 +3138,6 @@ RUN emacs \+1 {os_fname}
 """.format(fname=__file__,
            fname_edit=RE_THIS_FILE_QUOTED,
            os_fname=re.escape(quote(os.__file__.rstrip("c")))))
-
-
-def test_edit_py_code_source():
-    src = py.code.Source("""
-    def bar():
-        set_trace()
-        return 42
-    """)
-    _, base_lineno = inspect.getsourcelines(test_edit_py_code_source)
-    dic = {'set_trace': set_trace}
-    exec(src.compile(), dic)  # 8th line from the beginning of the function
-    bar = dic['bar']
-    src_compile_lineno = base_lineno + 8
-
-    check(bar, r"""
-[NUM] > .*bar()
--> return 42
-   5 frames hidden .*
-# edit bar
-RUN emacs \+%d %s
-# c
-""" % (src_compile_lineno, RE_THIS_FILE_CANONICAL_QUOTED))
 
 
 def test_put():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}, pypy3
+envlist = py{38,39,310,311,312}, pypy3
 
 [testenv]
 extras = testing

--- a/tox.ini
+++ b/tox.ini
@@ -27,4 +27,4 @@ commands = pytest {posargs}
 deps =
     ruff
 commands =
-    ruff src testing
+    ruff check src testing

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,9 @@ envlist = py{38,39,310,311}, pypy3
 [testenv]
 extras = testing
 deps =
-    # Pinned for https://github.com/nedbat/coveragepy/issues/1402.
-    coverage: coverage<=6.4.0
     coverage: pytest-cov
     ipython: IPython
     pexpect
-    # For tox's --force-dep to work (https://github.com/tox-dev/tox/issues/1199).
     pytest
 setenv =
     coverage: PYTEST_ADDOPTS=--cov "--cov-report=xml:{toxinidir}/coverage.xml" --cov-report=term-missing {env:PYTEST_ADDOPTS:}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,38,39}, py{py,py3}
+envlist = py{38,39,310,311}, pypy3
 
 [testenv]
 extras = testing

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,6 @@ commands = pytest {posargs}
 
 [testenv:checkqa]
 deps =
-    flake8
+    ruff
 commands =
-    flake8 src testing
+    ruff src testing


### PR DESCRIPTION
@blueyed I based this PR on your latest work in #524

The idea is to drop old python versions (#525) and to improve github actions in the process

- Add `lint` github actions workflow (uses `checkqa` tox env)
- drop versions below 3.8 in tox.ini, setup.py and github actions
- format code with black/isort
- add ruff linter
- drop most of the pre-3.8 code