### PR TITLE
Fixing loading of original pdb in embedded Python

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -100,9 +100,14 @@ def import_from_stdlib(name):
 
     stdlibdir, _ = os.path.split(code.__file__)
     pyfile = os.path.join(stdlibdir, name + '.py')
-    with open(pyfile) as f:
-        src = f.read()
-    co_module = compile(src, pyfile, 'exec', dont_inherit=True)
+    if os.path.isdir(stdlibdir):
+        with open(pyfile) as f:
+            src = f.read()
+        co_module = compile(src, pyfile, 'exec', dont_inherit=True)
+    if os.path.isfile(stdlibdir):
+        import zipimport
+        zi = zipimport.zipimporter(stdlibdir)
+        co_module = zi.get_code(name)
     exec(co_module, result.__dict__)
 
     return result


### PR DESCRIPTION
If you are using embedded Python, then 
`code.__file__ == 'PATH_TO_EMBEDDED\\python310.zip\\code.pyc`
And `stdlibdir` is a zip archive with .pyc files, so we need to read the compiled module code from it using `zipimport`.