### PR TITLE
Fix the `pdbpp_hijack_pdb.pth` injection for Python 3.13+

### DIFF
--- a/pdbpp_hijack_pdb.pth
+++ b/pdbpp_hijack_pdb.pth
@@ -7,5 +7,4 @@
 #    i.e. PDBPP_HIJACK_PDB=0 can be used to disable it.
 # 2. there is not another one already at the beginning
 #    (e.g. via a virtualenv using "include-system-site-packages")
-import os; _pdbpp_path = os.path.sep + "_pdbpp_path_hack"
-import sys; sys.path.insert(0, makepath(sitedir, "_pdbpp_path_hack")[0]) if int(os.environ.get('PDBPP_HIJACK_PDB', 1)) and not sys.path[0].endswith(_pdbpp_path) else None
+import os, sys; sys.path.insert(0, makepath(sitedir, "_pdbpp_path_hack")[0]) if int(os.environ.get('PDBPP_HIJACK_PDB', 1)) and not sys.path[0].endswith(os.path.sep + "_pdbpp_path_hack") else None


### PR DESCRIPTION
Since Python 3.13, lines in `pth` files cannot make use of variable assignments any more (due to changes to the `exec` built-in which is used to execute individual lines). Therefore, compress the code into a single line.